### PR TITLE
✨ Feat: PageHeader 컴포넌트 구현

### DIFF
--- a/src/components/ui/common/pageHeader/PageHeader.tsx
+++ b/src/components/ui/common/pageHeader/PageHeader.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import React from 'react';
+import {
+  BackButton,
+  Title,
+  Wrapper,
+} from '@components/ui/common/pageHeader/pageHeader.recipe';
+
+import { BackIcon } from '@/components/icons';
+
+/**
+ * `PageHeader`는 모바일 페이지 상단에 고정된 헤더 컴포넌트입니다.
+ *
+ * - 좌측에는 항상 `<` 아이콘(뒤로가기)이 표시됩니다.
+ * - 중앙에는 `title` 텍스트가 위치합니다.
+ * - 뒤로가기 버튼 클릭 시 `onBackButtonClick`이 전달되면 실행되며,
+ *   전달되지 않은 경우 기본적으로 `window.history.back()`을 수행합니다.
+ *
+ * @example
+ * ```tsx
+ * <PageHeader title="북마크" />
+ * ```
+ *
+ * @param title 페이지 타이틀 텍스트
+ * @param onBackButtonClick 뒤로가기 버튼 클릭 시 실행할 콜백 함수 (선택)
+ */
+type PageHeaderProps = {
+  /** 페이지 타이틀 텍스트 */
+  title: string;
+
+  /** 뒤로가기 버튼 클릭 시 실행할 콜백 (기본: window.history.back()) */
+  onBackButtonClick?: () => void;
+};
+
+function PageHeader({ title, onBackButtonClick }: PageHeaderProps) {
+  return (
+    <div className={Wrapper()}>
+      <button
+        type="button"
+        className={BackButton()}
+        onClick={
+          onBackButtonClick ??
+          (() => {
+            window.history.back();
+          })
+        }
+      >
+        <BackIcon />
+      </button>
+      <h1 className={Title()}>{title}</h1>
+    </div>
+  );
+}
+
+export default PageHeader;

--- a/src/components/ui/common/pageHeader/pageHeader.recipe.ts
+++ b/src/components/ui/common/pageHeader/pageHeader.recipe.ts
@@ -1,0 +1,36 @@
+import { cva } from '@root/styled-system/css';
+
+export const Wrapper = cva({
+  base: {
+    display: {
+      base: 'flex',
+      md: 'none',
+    },
+    alignItems: 'center',
+    height: '48px',
+    paddingX: '16px',
+  },
+});
+
+export const BackButton = cva({
+  base: {
+    display: {
+      base: 'block',
+      md: 'none',
+    },
+    bg: 'gray.100',
+    cursor: 'pointer',
+    padding: '4px',
+    borderRadius: 'full',
+    position: 'absolute',
+    left: '16px',
+  },
+});
+
+export const Title = cva({
+  base: {
+    marginX: 'auto',
+    textAlign: 'center',
+    textStyle: 'pageTitle',
+  },
+});


### PR DESCRIPTION
## 🔗 관련 이슈

- 이 PR이 해결하는 이슈 번호를 명시해주세요.
- close #21 

## 📝 작업 목록

- [x] 페이지 헤더 컴포넌트 구현
- [x] 모바일 화면에서만 보이고 pc에서는 숨김

## 🙋‍♀️ 기타 참고사항(선택)
- 리뷰어가 참고하면 좋을 내용이 있다면 적어주세요. (스크린샷, 리뷰 요구사항 등)
- 페이지헤더 컴포넌트는 사용할 곳에서 가져다 쓰면 됩니다.
- 피그마 상에서 ui가 틀려서 루트레이아웃에 안 넣었어요
- 기본값은 title은 필수로 줘야 합니다. 
- onBackButtonClick은 선택 사항입니다. 만약 주지 않는다면 기본적으로 뒤로 가기로 구현 했어요 

![스크린샷 2025-05-30 140355](https://github.com/user-attachments/assets/4bed14cd-0a31-4000-84a5-a497f6569ed9)


