### PR TITLE
✨ Feat: 스팟별 스토리 리스트 페이지 구현

### DIFF
--- a/src/app/story/search/page.tsx
+++ b/src/app/story/search/page.tsx
@@ -1,0 +1,13 @@
+import { Suspense } from 'react';
+
+import StoryPlaceList from '@/components/story/StoryPlaceList';
+
+function page() {
+  return (
+    <Suspense fallback={<div>로딩 중</div>}>
+      <StoryPlaceList />
+    </Suspense>
+  );
+}
+
+export default page;

--- a/src/components/story/StoryPlaceList.tsx
+++ b/src/components/story/StoryPlaceList.tsx
@@ -33,7 +33,7 @@ function StoryPlaceList() {
         <div className={flex({ gap: 'lg' })}>
           <div className={flexBetween()}>
             <div>
-              <span className={modalText({ text: 'head3' })}>{query}</span>
+              <span className={modalText({ text: 'sub2' })}>{query}</span>
               <p
                 className={cx(
                   flex({ direction: 'row', align: 'center', gap: 'xs' }),

--- a/src/components/story/StoryPlaceList.tsx
+++ b/src/components/story/StoryPlaceList.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import { useRouter, useSearchParams } from 'next/navigation';
+
+import { CalendarIcon, EllipsisIcon, LocationIcon } from '@/components/icons';
+import { gridLayout } from '@/components/map/map.recipe';
+import {
+  flex,
+  flexBetween,
+  subText,
+  titleText,
+  topRightAbsolute,
+} from '@/components/ui/common/cards/card.recipe';
+import SquareCard from '@/components/ui/common/cards/SquareCard';
+import { modalText } from '@/components/ui/common/modals/modal.recipe';
+import { placeStoryList } from '@/mocks/placeStoryList';
+
+import { cx } from '@root/styled-system/css';
+
+function StoryPlaceList() {
+  const router = useRouter();
+
+  const searchParams = useSearchParams();
+  const query = searchParams.get('query') || '';
+
+  const data = placeStoryList;
+
+  return (
+    <div className={flex({ p: 'sm', marginB: 'sm' })}>
+      {query.trim() === '' || data.length < 1 ? (
+        <p>검색 결과가 없습니다.</p>
+      ) : (
+        <div className={flex({ gap: 'lg' })}>
+          <div className={flexBetween()}>
+            <div>
+              <span className={modalText({ text: 'head3' })}>{query}</span>
+              <p
+                className={cx(
+                  flex({ direction: 'row', align: 'center', gap: 'xs' }),
+                  modalText({ text: 'body2', color: 'gray400' }),
+                )}
+              >
+                <LocationIcon width={20} height={20} />
+                {data[0].location}
+              </p>
+            </div>
+            <EllipsisIcon width={28} height={28} />
+          </div>
+          <div className={gridLayout()}>
+            {data.map(story => (
+              <SquareCard
+                key={story.id}
+                image={story.image}
+                liked={story.liked}
+                custom
+                onClick={() => router.push(`/story/${story.id}`)}
+              >
+                <div className={flex({ position: 'relative', gap: 'xs' })}>
+                  <p className={titleText()}>{story.author}</p>
+                  <p
+                    className={flex({
+                      direction: 'row',
+                      align: 'center',
+                      gap: 'xs',
+                    })}
+                  >
+                    <CalendarIcon />
+                    <span className={subText({ color: 'muted', clamp: 1 })}>
+                      {story.date}
+                    </span>
+                  </p>
+                  <span className={topRightAbsolute({ right: 2 })}>😀</span>
+                </div>
+              </SquareCard>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default StoryPlaceList;

--- a/src/components/ui/common/cards/SquareCard.tsx
+++ b/src/components/ui/common/cards/SquareCard.tsx
@@ -67,7 +67,7 @@ function SquareCard({
       })}
       onClick={onClick}
     >
-      <div className={cardImageWrapper({ maxWidth: 'none' })}>
+      <div className={cardImageWrapper({ maxWidth: 'none', aspect: 87 })}>
         <Image
           src={image || defaultThumbnail}
           alt={title || '카드이미지'}

--- a/src/components/ui/common/cards/card.recipe.ts
+++ b/src/components/ui/common/cards/card.recipe.ts
@@ -189,6 +189,7 @@ export const cardImageWrapper = cva({
       square: { aspectRatio: '1' },
       wide: { aspectRatio: '3/2' },
       video: { aspectRatio: '16/9' },
+      87: { aspectRatio: '8/7' },
     },
     maxWidth: {
       none: {},

--- a/src/components/ui/common/cards/card.recipe.ts
+++ b/src/components/ui/common/cards/card.recipe.ts
@@ -77,6 +77,10 @@ export const flex = cva({
   },
   variants: {
     width: { full: { width: 'full' }, auto: { width: 'auto' } },
+    position: {
+      relative: { position: 'relative' },
+      static: { position: 'static' },
+    },
     direction: {
       row: { flexDirection: 'row' },
       col: { flexDirection: 'column' },
@@ -266,6 +270,7 @@ export const topRightAbsolute = cva({
     right: {
       0: { right: '0' },
       1: { right: '1' },
+      2: { right: '2' },
       3: { right: '3' },
       5: { right: '5' },
     },

--- a/src/mocks/placeStoryList.ts
+++ b/src/mocks/placeStoryList.ts
@@ -1,0 +1,32 @@
+export const placeStoryList = [
+  {
+    id: 1,
+    image: '/images/story-sample.png',
+    placename: '부산어린이대공원',
+    location: '부산 진구 새싹로 295',
+    author: '홍선성현형',
+    date: '2025.04.25',
+    feeling: 'bad',
+    liked: false,
+  },
+  {
+    id: 2,
+    image: '/images/story-sample.png',
+    placename: '부산어린이대공원',
+    location: '부산 진구 새싹로 295',
+    author: '디자이너리',
+    date: '2025.04.25',
+    feeling: 'bad',
+    liked: true,
+  },
+  {
+    id: 3,
+    image: '/images/story-sample.png',
+    placename: '부산어린이대공원',
+    location: '부산 진구 새싹로 295',
+    author: '홍선성현형',
+    date: '2025.04.25',
+    feeling: 'bad',
+    liked: true,
+  },
+];


### PR DESCRIPTION
## 🔗 관련 이슈

Closes #50

## 📝 작업 목록

- [x] 스토리 리스트 페이지 구현
- [x] 스토리 리스트에서 상세 페이지로 라우팅 처리
- [x] ui 테스트를 위한 mock 데이터 추가

## 🙋‍♀️ 기타 참고사항(선택)

<img width="376" alt="스크린샷 2025-06-08 오후 4 15 41" src="https://github.com/user-attachments/assets/0e5b62c4-b27d-48bd-9e98-cbbd09159201" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
	- 장소와 관련된 스토리 검색 결과를 보여주는 검색 페이지가 추가되었습니다.
	- 검색 결과가 없을 경우 안내 메시지가 표시됩니다.
	- 각 스토리는 카드 형태로 이미지, 좋아요 여부, 작성자, 날짜, 이모지와 함께 표시되며, 클릭 시 상세 페이지로 이동할 수 있습니다.
- **스타일**
	- 카드 이미지의 비율 및 위치 옵션이 추가되어 레이아웃이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->