### PR TITLE
♻️ Refactor: 홈 페이지 카드 컴포넌트로 변경

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -33,7 +33,7 @@ export default function Home() {
       <SearchStorySection />
       <SubscribeTeaserSection />
       <article>
-        <div className={css({ textAlign: 'center' })}>
+        <div className={css({ textAlign: 'center', mb: '24' })}>
           <h1 className={scrollSubText()}>함께할 준비가 되었나요?</h1>
           <Button size="lg">구독하러 가기</Button>
         </div>

--- a/src/components/home/recipes/HomeSection.recipe.ts
+++ b/src/components/home/recipes/HomeSection.recipe.ts
@@ -94,14 +94,12 @@ export const subscribeBenefitGrid = cva({
 export const subscribeBenefitCard = cva({
   base: {
     display: 'flex',
-    flexDirection: 'column',
     alignItems: 'center',
-    justifyContent: 'center',
+    justifyContent: 'space-between',
     gap: 2,
     width: '100%',
     bg: 'white',
     borderRadius: 'md',
     textAlign: 'center',
-    boxShadow: 'sm',
   },
 });

--- a/src/components/home/sections/ScrollMarkerSection.tsx
+++ b/src/components/home/sections/ScrollMarkerSection.tsx
@@ -25,7 +25,7 @@ function ScrollMarkerSection() {
             숨은 로컬 맛집 <br /> 찾기가 더 간편해졌어요
           </h1>
           <h2 className={css({ textStyle: 'headline3' })}>
-            여행을 하눈에, 그리고 한 번에!
+            여행을 한눈에, 그리고 한 번에!
           </h2>
           <p className={scrollDescription()}>
             다른 곳에서는 없던 현지인 로컬 명소를 <br />

--- a/src/components/home/sections/SubscribeTeaserSection.tsx
+++ b/src/components/home/sections/SubscribeTeaserSection.tsx
@@ -8,7 +8,7 @@ import {
   scrollDescription,
   scrollSubText,
 } from '@components/home/recipes/text.recipe';
-import { BookIcon, HomeMarkerIcon } from '@components/icons';
+import BenefitCard from '@components/ui/common/cards/BenefitCard';
 
 import { css } from '@root/styled-system/css';
 
@@ -23,36 +23,16 @@ function SubscribeTeaserSection() {
       </div>
       <div className={subscribeBenefitGrid()}>
         <div className={subscribeBenefitCard()}>
-          <div className={css({ marginTop: '1rem' })}>
-            <BookIcon width={30} height={30} />
+          <div className={css({ width: '100%' })}>
+            <BenefitCard
+              title="스토리"
+              icon="book"
+              content="무제한 스토리 열람"
+            />
           </div>
-          <p>스토리</p>
-          <p className={css({ color: 'gray.700', marginBottom: '1rem' })}>
-            무제한{' '}
-            <span
-              className={css({
-                color: 'blue',
-              })}
-            >
-              스토리 열람
-            </span>
-          </p>
-        </div>
-        <div className={subscribeBenefitCard()}>
-          <div className={css({ marginTop: '1rem' })}>
-            <HomeMarkerIcon width={30} height={30} />
+          <div className={css({ width: '100%' })}>
+            <BenefitCard title="지도" icon="map" content="무제한 지도 열람" />
           </div>
-          <p>지도</p>
-          <p className={css({ color: 'gray.700', marginBottom: '1rem' })}>
-            무제한{' '}
-            <span
-              className={css({
-                color: 'blue',
-              })}
-            >
-              지도 열람
-            </span>
-          </p>
         </div>
       </div>
     </article>


### PR DESCRIPTION
## 🔗 관련 이슈

- 이 PR이 해결하는 이슈 번호를 명시해주세요.
- Close #57 

## 📝 작업 목록

- [x] 카드 스토리, 지도 하드코딩된거 카드 컴포넌트로 변경

## 🙋‍♀️ 기타 참고사항(선택)

- 리뷰어가 참고하면 좋을 내용이 있다면 적어주세요. (스크린샷, 리뷰 요구사항 등)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **스타일**
  - 홈 화면의 마지막 기사 섹션에 하단 여백이 추가되어 콘텐츠 간 간격이 넓어졌습니다.
  - 구독 혜택 카드의 정렬 및 그림자 효과가 변경되어 시각적 레이아웃이 개선되었습니다.

- **리팩터**
  - 구독 혜택 카드 UI가 재사용 가능한 컴포넌트로 통합되어 코드 구조가 간소화되었습니다.

- **버그 수정**
  - 홈 화면 스크롤 마커 섹션의 한국어 문구 오타가 수정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->