### PR TITLE
💄 Design: 페이지 레이아웃 및 반응형 수정

### DIFF
--- a/src/app/map/[id]/page.tsx
+++ b/src/app/map/[id]/page.tsx
@@ -27,22 +27,24 @@ function page() {
           <Likes liked={data.liked} />
         </span>
       </div>
-      <div className={flex({ gap: 'md' })}>
-        <p className={modalText({ text: 'head3', align: 'left' })}>
-          {data.title}
-        </p>
-        <p
-          className={modalText({
-            text: 'body2',
-            flex: 'row',
-            gap: 1,
-            align: 'left',
-            color: 'gray400',
-          })}
-        >
-          <LocationIcon width={20} height={20} />
-          {data.location}
-        </p>
+      <div className={flex({ gap: 'lg' })}>
+        <div className={flex({ gap: 'sm' })}>
+          <p className={modalText({ text: 'head3', align: 'left' })}>
+            {data.title}
+          </p>
+          <p
+            className={modalText({
+              text: 'body2',
+              flex: 'row',
+              gap: 1,
+              align: 'left',
+              color: 'gray400',
+            })}
+          >
+            <LocationIcon width={20} height={20} />
+            {data.location}
+          </p>
+        </div>
         <p
           className={modalText({
             text: 'body3',

--- a/src/app/map/layout.tsx
+++ b/src/app/map/layout.tsx
@@ -1,4 +1,4 @@
-import MapSearchBar from '@/components/map/MapSearchBar';
+import SearchBar from '@/components/map/SearchBar';
 import PageHeader from '@/components/ui/common/pageHeader/PageHeader';
 
 import { css } from '@root/styled-system/css';
@@ -7,8 +7,11 @@ function layout({ children }: { children: React.ReactNode }) {
   return (
     <>
       <PageHeader>
-        <MapSearchBar />
+        <SearchBar />
       </PageHeader>
+      <div className={css({ display: { base: 'none', md: 'flex' } })}>
+        <SearchBar />
+      </div>
       <div className={css({ width: 'full', overflow: 'auto', marginTop: 3 })}>
         {children}
       </div>

--- a/src/app/story/post/page.tsx
+++ b/src/app/story/post/page.tsx
@@ -1,7 +1,13 @@
 import StoryPostForm from '@/components/story/StoryPostForm';
+import PageHeader from '@/components/ui/common/pageHeader/PageHeader';
 
 function page() {
-  return <StoryPostForm />;
+  return (
+    <>
+      <PageHeader title="스토리" />
+      <StoryPostForm />
+    </>
+  );
 }
 
 export default page;

--- a/src/app/story/search/page.tsx
+++ b/src/app/story/search/page.tsx
@@ -1,12 +1,20 @@
 import { Suspense } from 'react';
 
+import SearchBar from '@/components/map/SearchBar';
 import StoryPlaceList from '@/components/story/StoryPlaceList';
 import PageHeader from '@/components/ui/common/pageHeader/PageHeader';
+
+import { css } from '@root/styled-system/css';
 
 function page() {
   return (
     <>
-      <PageHeader title="스토리" />
+      <PageHeader>
+        <SearchBar basePath="story" />
+      </PageHeader>
+      <div className={css({ display: { base: 'none', md: 'flex' } })}>
+        <SearchBar basePath="story" />
+      </div>
       <Suspense fallback={<div>로딩 중</div>}>
         <StoryPlaceList />
       </Suspense>

--- a/src/app/story/search/page.tsx
+++ b/src/app/story/search/page.tsx
@@ -1,12 +1,16 @@
 import { Suspense } from 'react';
 
 import StoryPlaceList from '@/components/story/StoryPlaceList';
+import PageHeader from '@/components/ui/common/pageHeader/PageHeader';
 
 function page() {
   return (
-    <Suspense fallback={<div>로딩 중</div>}>
-      <StoryPlaceList />
-    </Suspense>
+    <>
+      <PageHeader title="스토리" />
+      <Suspense fallback={<div>로딩 중</div>}>
+        <StoryPlaceList />
+      </Suspense>
+    </>
   );
 }
 

--- a/src/components/map/MapDetailStory.tsx
+++ b/src/components/map/MapDetailStory.tsx
@@ -31,6 +31,7 @@ function MapDetailStory({ title, images }: MapDetailStoryProps) {
             text: 'label2',
             color: 'blue500',
             cursor: 'pointer',
+            hover: 'on',
           })}
           onClick={() => router.push(`/story/search?query=${title}`)}
         >

--- a/src/components/map/MapDetailStory.tsx
+++ b/src/components/map/MapDetailStory.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Image from 'next/image';
+import { useRouter } from 'next/navigation';
 
 import { gridLayout } from '@/components/map/map.recipe';
 import { flex, flexBetween } from '@/components/ui/common/cards/card.recipe';
@@ -12,6 +13,8 @@ type MapDetailStoryProps = {
 };
 
 function MapDetailStory({ title, images }: MapDetailStoryProps) {
+  const router = useRouter();
+
   return (
     <div className={flex({ gap: 'md' })}>
       <p className={flexBetween()}>
@@ -29,6 +32,7 @@ function MapDetailStory({ title, images }: MapDetailStoryProps) {
             color: 'blue500',
             cursor: 'pointer',
           })}
+          onClick={() => router.push(`/story/search?query=${title}`)}
         >
           더보기
         </span>

--- a/src/components/map/MapDetailStory.tsx
+++ b/src/components/map/MapDetailStory.tsx
@@ -33,7 +33,9 @@ function MapDetailStory({ title, images }: MapDetailStoryProps) {
             cursor: 'pointer',
             hover: 'on',
           })}
-          onClick={() => router.push(`/story/search?query=${title}`)}
+          onClick={() =>
+            router.push(`/story/search?query=${encodeURIComponent(title)}`)
+          }
         >
           더보기
         </span>

--- a/src/components/map/MapResults.tsx
+++ b/src/components/map/MapResults.tsx
@@ -25,7 +25,7 @@ function MapResults({ query }: { query: string }) {
       ) : (
         <div className={flex({ gap: 'lg' })}>
           <div className={flexBetween()}>
-            <span className={modalText({ text: 'sub2' })}>{query}</span>
+            <span className={modalText({ text: 'search' })}>{query}</span>
             <div>
               <FilterDropdown
                 options={MAP_DROPDOWN_OPTIONS}

--- a/src/components/map/MapTabs.tsx
+++ b/src/components/map/MapTabs.tsx
@@ -34,6 +34,7 @@ function MapTabs() {
               textStyle: selectedTab === value ? 'label1' : 'body2',
               active: selectedTab === value,
               cursor: 'pointer',
+              hover: 'on',
             })}
             onClick={() => setSelectedTab(value)}
           >

--- a/src/components/map/SearchBar.tsx
+++ b/src/components/map/SearchBar.tsx
@@ -33,23 +33,30 @@ function SearchBar({
   };
 
   return (
-    <>
-      <div
+    <div
+      className={css({
+        flex: 1,
+        display: 'flex',
+        justifyContent: { base: 'center', md: 'flex-start' },
+        alignItems: 'center',
+        gap: { base: '6%', md: 4 },
+        paddingLeft: { base: '6%', md: 2 },
+        textAlign: 'center',
+      })}
+    >
+      <form
+        onSubmit={onSubmit}
         className={css({
           flex: 1,
-          marginLeft: 10,
-          paddingX: '5%',
-          textAlign: 'center',
+          maxWidth: { base: '100%', md: '350px' },
         })}
       >
-        <form onSubmit={onSubmit}>
-          <Search
-            placeholder={placeholder}
-            value={query}
-            onChange={e => setQuery(e.target.value)}
-          />
-        </form>
-      </div>
+        <Search
+          placeholder={placeholder}
+          value={query}
+          onChange={e => setQuery(e.target.value)}
+        />
+      </form>
       {basePath === 'map' && (
         <div
           className={iconWrapper()}
@@ -58,7 +65,7 @@ function SearchBar({
           <GpsLocationIcon fill="#707070" />
         </div>
       )}
-    </>
+    </div>
   );
 }
 

--- a/src/components/map/SearchBar.tsx
+++ b/src/components/map/SearchBar.tsx
@@ -9,7 +9,15 @@ import { Search } from '@/components/ui/common/textfields';
 
 import { css } from '@root/styled-system/css';
 
-function MapSearchBar() {
+type SearchBarProps = {
+  basePath?: string;
+  placeholder?: string;
+};
+
+function SearchBar({
+  basePath = 'map',
+  placeholder = 'Search',
+}: SearchBarProps) {
   const router = useRouter();
 
   const [query, setQuery] = useState('');
@@ -17,7 +25,9 @@ function MapSearchBar() {
   const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (query.trim()) {
-      router.push(`/map/search?query=${encodeURIComponent(query.trim())}`);
+      router.push(
+        `/${basePath}/search?query=${encodeURIComponent(query.trim())}`,
+      );
       setQuery('');
     }
   };
@@ -28,23 +38,28 @@ function MapSearchBar() {
         className={css({
           flex: 1,
           marginLeft: 10,
-          paddingX: 3,
+          paddingX: '5%',
           textAlign: 'center',
         })}
       >
         <form onSubmit={onSubmit}>
           <Search
-            placeholder="Search"
+            placeholder={placeholder}
             value={query}
             onChange={e => setQuery(e.target.value)}
           />
         </form>
       </div>
-      <div className={iconWrapper()} onClick={() => router.push('/map/search')}>
-        <GpsLocationIcon fill="#707070" />
-      </div>
+      {basePath === 'map' && (
+        <div
+          className={iconWrapper()}
+          onClick={() => router.push('/map/search')}
+        >
+          <GpsLocationIcon fill="#707070" />
+        </div>
+      )}
     </>
   );
 }
 
-export default MapSearchBar;
+export default SearchBar;

--- a/src/components/map/map.recipe.ts
+++ b/src/components/map/map.recipe.ts
@@ -62,6 +62,13 @@ export const categoryTitle = cva({
     cursor: {
       pointer: { cursor: 'pointer' },
     },
+    hover: {
+      on: {
+        _hover: {
+          transform: 'scale(1.05)',
+        },
+      },
+    },
   },
   defaultVariants: {
     textStyle: 'body3',

--- a/src/components/story/StoryPlaceList.tsx
+++ b/src/components/story/StoryPlaceList.tsx
@@ -27,7 +27,7 @@ function StoryPlaceList() {
   const data = placeStoryList;
 
   return (
-    <div className={flex({ p: 'sm', marginB: 'sm' })}>
+    <div className={flex({ p: 'sm', marginT: 'sm', marginB: 'sm' })}>
       {query.trim() === '' || data.length < 1 ? (
         <p>검색 결과가 없습니다.</p>
       ) : (

--- a/src/components/story/StoryPlaceList.tsx
+++ b/src/components/story/StoryPlaceList.tsx
@@ -16,7 +16,7 @@ import { modalText } from '@/components/ui/common/modals/modal.recipe';
 import FeelingIcon from '@/components/ui/feelings/FeelingIcon';
 import { placeStoryList } from '@/mocks/placeStoryList';
 
-import { cx } from '@root/styled-system/css';
+import { css, cx } from '@root/styled-system/css';
 
 function StoryPlaceList() {
   const router = useRouter();
@@ -33,8 +33,10 @@ function StoryPlaceList() {
       ) : (
         <div className={flex({ gap: 'lg' })}>
           <div className={flexBetween()}>
-            <div>
-              <span className={modalText({ text: 'sub2' })}>{query}</span>
+            <div className={flex({ gap: 'xs' })}>
+              <span className={modalText({ text: 'search', align: 'left' })}>
+                {query}
+              </span>
               <p
                 className={cx(
                   flex({ direction: 'row', align: 'center', gap: 'xs' }),
@@ -47,7 +49,17 @@ function StoryPlaceList() {
             </div>
             <EllipsisIcon width={28} height={28} />
           </div>
-          <div className={gridLayout()}>
+          <div
+            className={cx(
+              gridLayout(),
+              css({
+                gridTemplateColumns: {
+                  base: 'repeat(2, 1fr)',
+                  md: 'repeat(4, 1fr)',
+                },
+              }),
+            )}
+          >
             {data.map(story => (
               <SquareCard
                 key={story.id}
@@ -56,7 +68,13 @@ function StoryPlaceList() {
                 custom
                 onClick={() => router.push(`/story/${story.id}`)}
               >
-                <div className={flex({ position: 'relative', gap: 'xs' })}>
+                <div
+                  className={flex({
+                    position: 'relative',
+                    gap: 'xs',
+                    p: 'xs',
+                  })}
+                >
                   <p className={titleText()}>{story.author}</p>
                   <p
                     className={flex({
@@ -70,8 +88,8 @@ function StoryPlaceList() {
                       {story.date}
                     </span>
                   </p>
-                  <span className={topRightAbsolute({ top: 0, right: 1 })}>
-                    <FeelingIcon value={story.feeling} />
+                  <span className={topRightAbsolute({ top: 1, right: 3 })}>
+                    <FeelingIcon size={24} value={story.feeling} />
                   </span>
                 </div>
               </SquareCard>

--- a/src/components/ui/common/cards/SquareCard.tsx
+++ b/src/components/ui/common/cards/SquareCard.tsx
@@ -81,7 +81,7 @@ function SquareCard({
       {custom ? (
         children
       ) : (
-        <div className={flex({ gap: 'sm' })}>
+        <div className={flex({ gap: 'sm', px: 'xs' })}>
           <p className={titleText()}>{title}</p>
           <p className={flex({ direction: 'row', align: 'center', gap: 'xs' })}>
             <LocationIcon width={16} height={16} />

--- a/src/components/ui/common/cards/WideCardContent.tsx
+++ b/src/components/ui/common/cards/WideCardContent.tsx
@@ -78,6 +78,7 @@ function WideCardContent({
         align: 'start',
         p: 'xs',
         shadow: 'none',
+        hover: 'off',
       })}
       onClick={onClick}
     >

--- a/src/components/ui/common/cards/WideCardContent.tsx
+++ b/src/components/ui/common/cards/WideCardContent.tsx
@@ -92,7 +92,7 @@ function WideCardContent({
       {rating && (
         <div className={flex({ direction: 'row', align: 'center', gap: 'sm' })}>
           <StarRating value={Number(rating)} />
-          <span className={subText()}>{rating}</span>
+          <span className={subText({ textStyle: 'rating' })}>{rating}</span>
         </div>
       )}
       {footerText && (

--- a/src/components/ui/common/cards/card.recipe.ts
+++ b/src/components/ui/common/cards/card.recipe.ts
@@ -106,7 +106,7 @@ export const flex = cva({
       md: { p: '4' },
       lg: { p: '6' },
     },
-    px: { sm: { paddingX: 3 }, lg: { px: '10' } },
+    px: { xs: { px: 1.5 }, sm: { px: 3 }, lg: { px: '10' } },
     marginB: {
       xs: { marginBottom: 2 },
       sm: { marginBottom: 4 },
@@ -170,6 +170,7 @@ export const subText = cva({
       body4: { textStyle: 'body4' },
       label1: { textStyle: 'label1' },
       label2: { textStyle: 'label2' },
+      rating: { fontSize: '14px', fontWeight: 500 },
     },
     clamp: {
       1: { lineClamp: 1, width: 'full' },

--- a/src/components/ui/common/cards/card.recipe.ts
+++ b/src/components/ui/common/cards/card.recipe.ts
@@ -50,6 +50,18 @@ export const cardWrapper = cva({
       none: { cursor: 'default' },
       pointer: { cursor: 'pointer' },
     },
+    hover: {
+      on: {
+        transition: 'transform 0.2s ease-in-out',
+        _hover: {
+          transform: 'scale(1.02)',
+        },
+      },
+      off: {
+        transition: 'none',
+        _hover: {},
+      },
+    },
   },
   defaultVariants: {
     position: 'relative',
@@ -60,6 +72,7 @@ export const cardWrapper = cva({
     radius: 'lg',
     shadow: 'sm',
     cursor: 'pointer',
+    hover: 'on',
   },
 });
 

--- a/src/components/ui/common/cards/card.recipe.ts
+++ b/src/components/ui/common/cards/card.recipe.ts
@@ -120,6 +120,9 @@ export const flex = cva({
       lg: { p: '6' },
     },
     px: { xs: { px: 1.5 }, sm: { px: 3 }, lg: { px: '10' } },
+    marginT: {
+      sm: { marginTop: 3 },
+    },
     marginB: {
       xs: { marginBottom: 2 },
       sm: { marginBottom: 4 },

--- a/src/components/ui/common/modals/modal.recipe.ts
+++ b/src/components/ui/common/modals/modal.recipe.ts
@@ -96,6 +96,13 @@ export const modalText = cva({
     cursor: {
       pointer: { cursor: 'pointer' },
     },
+    hover: {
+      on: {
+        _hover: {
+          transform: 'scale(1.05)',
+        },
+      },
+    },
   },
   defaultVariants: {
     align: 'center',

--- a/src/components/ui/common/modals/modal.recipe.ts
+++ b/src/components/ui/common/modals/modal.recipe.ts
@@ -78,6 +78,7 @@ export const modalText = cva({
       body3: { textStyle: 'body3' },
       label1: { textStyle: 'label1' },
       label2: { textStyle: 'label2' },
+      search: { fontSize: '20px', fontWeight: 600 },
     },
     align: {
       left: { textAlign: 'left' },

--- a/src/components/ui/common/pageHeader/pageHeader.recipe.ts
+++ b/src/components/ui/common/pageHeader/pageHeader.recipe.ts
@@ -8,6 +8,7 @@ export const Wrapper = cva({
     },
     alignItems: 'center',
     height: '48px',
+    position: 'relative',
   },
 });
 
@@ -21,14 +22,14 @@ export const BackButton = cva({
     cursor: 'pointer',
     padding: 2,
     borderRadius: 'full',
-    position: 'absolute',
-    left: '16px',
   },
 });
 
 export const Title = cva({
   base: {
-    marginX: 'auto',
+    position: 'absolute',
+    left: '50%',
+    transform: 'translateX(-50%)',
     textAlign: 'center',
     textStyle: 'pageTitle',
   },


### PR DESCRIPTION
## 🔗 관련 이슈

Closes #65 

## 📝 작업 목록

- [x] 스토리 페이지 내부 헤더 추가
- [x] 지도 서치바 스토리에서도 사용 가능하도록 확장
- [x] 지도 상세 페이지에서 스팟별 스토리 리스트로 라우팅 처리
- [x] 반응형 레이아웃 적용
- [x] hover 효과 적용

## 🙋‍♀️ 기타 참고사항(선택)

- 리뷰어가 참고하면 좋을 내용이 있다면 적어주세요. (스크린샷, 리뷰 요구사항 등)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 다양한 경로에서 사용할 수 있는 새로운 검색 바가 추가되었습니다.
  - 스토리 페이지 및 지도 페이지에 반응형 검색 바가 도입되어 중간 이상 화면에서 추가 검색 인터페이스를 제공합니다.
  - 스토리 페이지에 제목이 포함된 헤더가 추가되었습니다.

- **버그 수정**
  - 지도 및 스토리 검색 결과, 카드, 탭 등에서 텍스트, 버튼, 카드 등에 호버 효과와 스타일이 개선되었습니다.
  - 일부 컴포넌트의 레이아웃 및 정렬 방식이 개선되어 UI 일관성이 향상되었습니다.
  - "더보기" 버튼에 클릭 시 스토리 검색으로 이동하는 기능이 추가되었습니다.

- **스타일**
  - 카드, 모달, 탭, 헤더 등 여러 UI 요소의 마진, 패딩, 폰트, 호버 효과가 조정되어 가독성과 사용성이 개선되었습니다.
  - 제목과 위치 정보의 레이아웃 간격 및 그룹화가 조정되어 시각적 구분이 명확해졌습니다.
  - 헤더 타이틀의 중앙 정렬 방식이 절대 위치 방식으로 변경되었습니다.

- **리팩터**
  - 기존 지도 검색 바가 새로운 검색 바 컴포넌트로 대체되었습니다.
  - 지도 검색 바 컴포넌트가 삭제되고 신규 검색 바 컴포넌트가 도입되었습니다.

- **문서화**
  - 사용자에게 직접 노출되는 변경 사항 없음.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->