### PR TITLE
🐛 Fix: 카카오 로그인 중복 요청 및 redirect_uri 인코딩 오류 수정

### DIFF
--- a/src/app/users/login/kakao/callback/page.tsx
+++ b/src/app/users/login/kakao/callback/page.tsx
@@ -21,7 +21,8 @@ function KakaoCallbackContent() {
       .then(({ access, refresh, user }) => {
         setAuth(user, access, refresh);
         localStorage.setItem('user', JSON.stringify(user));
-        localStorage.setItem('token', JSON.stringify({ access, refresh }));
+        localStorage.setItem('access', access);
+        localStorage.setItem('refresh', refresh);
         router.push('/');
       })
       .catch(err => {

--- a/src/app/users/login/kakao/callback/page.tsx
+++ b/src/app/users/login/kakao/callback/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Suspense, useEffect } from 'react';
+import { Suspense, useEffect, useRef } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 
 import { postKakaoLoginCode } from '@/app/api/login/loginApi';
@@ -8,26 +8,26 @@ import { SpinnerMessage } from '@/components/ui/common/loading/SpinnerMessage';
 import { useAuthStore } from '@/store/useAuthStore';
 
 function KakaoCallbackContent() {
-  const params = useSearchParams();
+  const code = useSearchParams().get('code');
   const router = useRouter();
   const setAuth = useAuthStore(state => state.setAuth);
+  const isRequested = useRef(false);
 
   useEffect(() => {
-    const code = params.get('code');
-    if (!code) return;
+    if (!code || isRequested.current) return;
+    isRequested.current = true;
 
     postKakaoLoginCode(code)
       .then(({ access, refresh, user }) => {
         setAuth(user, access, refresh);
         localStorage.setItem('user', JSON.stringify(user));
-        localStorage.setItem('access', access);
-        localStorage.setItem('refresh', refresh);
+        localStorage.setItem('token', JSON.stringify({ access, refresh }));
         router.push('/');
       })
       .catch(err => {
         console.error('카카오 로그인 실패:', err);
       });
-  }, [params, router, setAuth]);
+  }, [code, router, setAuth]);
 
   return <SpinnerMessage message="로그인 중입니다..." />;
 }

--- a/src/constants/auth.ts
+++ b/src/constants/auth.ts
@@ -1,4 +1,4 @@
 export const KAKAO_REST_API_KEY = process.env.NEXT_PUBLIC_KAKAO_REST_API_KEY!;
 export const KAKAO_REDIRECT_URI = process.env.NEXT_PUBLIC_KAKAO_REDIRECT_URI!;
 
-export const KAKAO_AUTH_URL = `https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=${KAKAO_REST_API_KEY}&redirect_uri=${KAKAO_REDIRECT_URI}`;
+export const KAKAO_AUTH_URL = `https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=${KAKAO_REST_API_KEY}&redirect_uri=${encodeURIComponent(KAKAO_REDIRECT_URI)}`;


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #78

## 📝 작업 목록
- [x] 카카오 로그인 중복 요청
- [x] redirect_uri 인코딩 오류 수정

## 🙋‍♀️ 기타 참고사항(선택)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
  - 카카오 로그인 시 로그인 요청이 중복 전송되지 않도록 개선되었습니다.
  - 토큰이 하나의 localStorage 키(`token`)에 JSON 형태로 저장되어 관리가 간소화되었습니다.
  - 카카오 인증 URL 내 리다이렉트 URI가 올바르게 인코딩되어 특수문자 관련 오류가 방지됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->