### PR TITLE
♻️ Refactor: axios instance 토큰 헤더 설정 방식 개선

### DIFF
--- a/src/api/instance.ts
+++ b/src/api/instance.ts
@@ -14,12 +14,18 @@ export const instance = axios.create({
   withCredentials: true,
 });
 
+export const setAuthHeader = (token: string) => {
+  instance.defaults.headers.common.Authorization = `Bearer ${token}`;
+};
+
 instance.interceptors.request.use(
   config => {
-    const token =
-      useAuthStore.getState().access || localStorage.getItem('access');
-    if (token && config.headers) {
-      config.headers.Authorization = `Bearer ${token}`;
+    if (typeof window !== 'undefined') {
+      const token =
+        useAuthStore.getState().access || localStorage.getItem('access');
+      if (!config.headers.Authorization && token) {
+        config.headers.Authorization = `Bearer ${token}`;
+      }
     }
     return config;
   },

--- a/src/api/instance.ts
+++ b/src/api/instance.ts
@@ -1,6 +1,8 @@
 /* eslint-disable no-param-reassign */
 import axios from 'axios';
 
+import { useAuthStore } from '@/store/useAuthStore';
+
 const BASE_URL = 'https://localstorymap.com/api';
 
 export const instance = axios.create({
@@ -14,7 +16,8 @@ export const instance = axios.create({
 
 instance.interceptors.request.use(
   config => {
-    const token = localStorage.getItem('token'); // 전역 상태 로직으로 변경
+    const token =
+      useAuthStore.getState().access || localStorage.getItem('access');
     if (token && config.headers) {
       config.headers.Authorization = `Bearer ${token}`;
     }

--- a/src/app/users/login/kakao/callback/page.tsx
+++ b/src/app/users/login/kakao/callback/page.tsx
@@ -3,6 +3,7 @@
 import { Suspense, useEffect, useRef } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 
+import { setAuthHeader } from '@/api/instance';
 import { postKakaoLoginCode } from '@/app/api/login/loginApi';
 import { SpinnerMessage } from '@/components/ui/common/loading/SpinnerMessage';
 import { useAuthStore } from '@/store/useAuthStore';
@@ -23,6 +24,7 @@ function KakaoCallbackContent() {
         localStorage.setItem('user', JSON.stringify(user));
         localStorage.setItem('access', access);
         localStorage.setItem('refresh', refresh);
+        setAuthHeader(access);
         router.push('/');
       })
       .catch(err => {


### PR DESCRIPTION
## 🔗 관련 이슈

Closes #78 

## 📝 작업 목록

- [x] axios instance에서 토큰 키값 수정(token > access)
- [x] instance 헤더 토큰 설정 방식 명시적으로 개선

## 🙋‍♀️ 기타 참고사항(선택)

- 리뷰어가 참고하면 좋을 내용이 있다면 적어주세요. (스크린샷, 리뷰 요구사항 등)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 카카오 로그인 후 인증 토큰이 즉시 전역 API 요청 헤더에 반영되어, 로그인 직후에도 인증이 필요한 기능을 원활하게 사용할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->