### PR TITLE
✨ Feat: 구글 로그인 API 연동

### DIFF
--- a/src/app/api/login/loginApi.ts
+++ b/src/app/api/login/loginApi.ts
@@ -1,7 +1,7 @@
 import { ENDPOINTS } from '@/api/endpoints';
 import { mutationFetcher } from '@/api/fetcher';
 
-interface KakaoLoginResponse {
+interface SocialLoginResponse {
   access: string;
   refresh: string;
   user: {
@@ -19,8 +19,16 @@ interface KakaoLoginResponse {
 
 export const postKakaoLoginCode = (
   code: string,
-): Promise<KakaoLoginResponse> => {
-  return mutationFetcher<KakaoLoginResponse>('post', ENDPOINTS.USERS.KAKAO, {
+): Promise<SocialLoginResponse> => {
+  return mutationFetcher<SocialLoginResponse>('post', ENDPOINTS.USERS.KAKAO, {
+    code,
+  });
+};
+
+export const postGoogleLoginCode = (
+  code: string,
+): Promise<SocialLoginResponse> => {
+  return mutationFetcher<SocialLoginResponse>('post', ENDPOINTS.USERS.GOOGLE, {
     code,
   });
 };

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -17,7 +17,7 @@ import {
 import { GoogleIcon } from '@/components/icons/shared/GoogleIcon';
 import { KakaoIcon } from '@/components/icons/shared/KakaoIcon';
 import { Button } from '@/components/ui/common/buttons/Button';
-import { KAKAO_AUTH_URL } from '@/constants/auth';
+import { GOOGLE_AUTH_URL, KAKAO_AUTH_URL } from '@/constants/auth';
 
 export default function LoginPage() {
   const [loadingProvider, setLoadingProvider] = useState<
@@ -34,8 +34,8 @@ export default function LoginPage() {
     setLoadingProvider(provider);
     if (provider === 'kakao') {
       window.location.href = KAKAO_AUTH_URL;
-    } else {
-      setTimeout(() => setLoadingProvider(null), 1000);
+    } else if (provider === 'google') {
+      window.location.href = GOOGLE_AUTH_URL;
     }
   };
 

--- a/src/app/users/login/google/callback/page.tsx
+++ b/src/app/users/login/google/callback/page.tsx
@@ -25,10 +25,6 @@ function GoogleCallbackContent() {
         const clientUser = apiUserToClientUser(user as ApiUser);
         setAuth(clientUser, access, refresh);
 
-        localStorage.setItem('user', JSON.stringify(clientUser));
-        localStorage.setItem('access', access);
-        localStorage.setItem('refresh', refresh);
-
         setAuthHeader(access);
         router.push('/');
       })

--- a/src/app/users/login/google/callback/page.tsx
+++ b/src/app/users/login/google/callback/page.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { Suspense, useEffect, useRef } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+
+import { setAuthHeader } from '@/api/instance';
+import { postGoogleLoginCode } from '@/app/api/login/loginApi';
+import { SpinnerMessage } from '@/components/ui/common/loading/SpinnerMessage';
+import { useAuthStore } from '@/store/useAuthStore';
+import { ApiUser, apiUserToClientUser } from '@/types/user';
+
+function GoogleCallbackContent() {
+  const code = useSearchParams().get('code');
+  const router = useRouter();
+  const setAuth = useAuthStore(state => state.setAuth);
+  const isRequested = useRef(false);
+
+  useEffect(() => {
+    if (!code || isRequested.current) return;
+
+    isRequested.current = true;
+
+    postGoogleLoginCode(code)
+      .then(({ access, refresh, user }) => {
+        const clientUser = apiUserToClientUser(user as ApiUser);
+        setAuth(clientUser, access, refresh);
+
+        localStorage.setItem('user', JSON.stringify(clientUser));
+        localStorage.setItem('access', access);
+        localStorage.setItem('refresh', refresh);
+
+        setAuthHeader(access);
+        router.push('/');
+      })
+      .catch(err => {
+        console.error('구글 로그인 실패:', err);
+      });
+  }, [code, router, setAuth]);
+
+  return <SpinnerMessage message="로그인 중입니다..." />;
+}
+
+export default function GoogleCallbackPage() {
+  return (
+    <Suspense fallback={<SpinnerMessage message="로딩 중..." />}>
+      <GoogleCallbackContent />
+    </Suspense>
+  );
+}

--- a/src/constants/auth.ts
+++ b/src/constants/auth.ts
@@ -1,4 +1,7 @@
 export const KAKAO_REST_API_KEY = process.env.NEXT_PUBLIC_KAKAO_REST_API_KEY!;
 export const KAKAO_REDIRECT_URI = process.env.NEXT_PUBLIC_KAKAO_REDIRECT_URI!;
-
 export const KAKAO_AUTH_URL = `https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=${KAKAO_REST_API_KEY}&redirect_uri=${encodeURIComponent(KAKAO_REDIRECT_URI)}`;
+
+export const GOOGLE_CLIENT_ID = process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID!;
+export const GOOGLE_REDIRECT_URI = process.env.NEXT_PUBLIC_GOOGLE_REDIRECT_URI!;
+export const GOOGLE_AUTH_URL = `https://accounts.google.com/o/oauth2/v2/auth?response_type=code&client_id=${GOOGLE_CLIENT_ID}&redirect_uri=${encodeURIComponent(GOOGLE_REDIRECT_URI)}&scope=${encodeURIComponent('https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/userinfo.email')}&access_type=offline&prompt=consent`;


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #112 

## 📝 작업 목록
- [x] 구글 로그인 연동
- [x] 로그인 상태 관리
- [x] 에러 핸들링 (로그인 실패, 토큰 만료 등은 instance.ts에서 공통 처리 예정)

## 🙋‍♀️ 기타 참고사항(선택)
<img width="1728" alt="스크린샷 2025-06-20 오전 11 23 24" src="https://github.com/user-attachments/assets/9418aba1-32eb-4c2c-afbc-52307e29038c" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
	- 구글 소셜 로그인을 지원합니다. 이제 구글 계정으로 로그인할 수 있습니다.
	- 구글 로그인 콜백 페이지가 추가되어 인증 후 자동으로 홈으로 이동합니다.

- **버그 수정**
	- 로그인 처리 시 구글과 카카오 각각에 맞는 인증 URL로 정확히 리디렉션됩니다.

- **기타**
	- 구글 로그인 인증 관련 환경 변수 및 상수가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->