### PR TITLE
✨ Feat: token refresh 로직 반영

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,6 +23,7 @@
     "no-unused-vars": "warn",
     "no-shadow": "off",
     "no-use-before-define": "off",
+    "no-underscore-dangle": ["warn", { "allow": ["_retry"] }],
 
     //react 관련
     "no-undef": "off",

--- a/src/api/instance.ts
+++ b/src/api/instance.ts
@@ -3,7 +3,7 @@ import axios from 'axios';
 
 import { useAuthStore } from '@/store/useAuthStore';
 
-const BASE_URL = 'https://localstorymap.com/api';
+export const BASE_URL = 'https://localstorymap.com/api';
 
 export const instance = axios.create({
   baseURL: BASE_URL,

--- a/src/api/instance.ts
+++ b/src/api/instance.ts
@@ -20,7 +20,7 @@ export const setAuthHeader = (token: string) => {
 };
 
 export const clearAuthHeader = () => {
-  delete instance.defaults.headers.common.Authorization;
+  instance.defaults.headers.common.Authorization = undefined;
 };
 
 if (typeof window !== 'undefined') {
@@ -43,8 +43,8 @@ if (typeof window !== 'undefined') {
       const originalRequest = error.config;
 
       if (
-        (error.response?.status === 401 || error.response?.status === 403) &&
-        !originalRequest._retry
+        error.response?.status === 401 ||
+        (error.response?.status === 403 && !originalRequest._retry)
       ) {
         originalRequest._retry = true;
 
@@ -52,13 +52,11 @@ if (typeof window !== 'undefined') {
         if (newAccessToken) {
           setAuthHeader(newAccessToken);
           originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
-
           return instance(originalRequest);
         }
 
         clearAuthHeader();
         useAuthStore.getState().clearAuth();
-        localStorage.clear();
         window.location.href = '/login';
       }
       return Promise.reject(error);

--- a/src/api/instance.ts
+++ b/src/api/instance.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-param-reassign */
 import axios from 'axios';
 
+import { refreshAccessToken } from '@/api/interceptor';
 import { useAuthStore } from '@/store/useAuthStore';
 
 export const BASE_URL = 'https://localstorymap.com/api';
@@ -18,26 +19,43 @@ export const setAuthHeader = (token: string) => {
   instance.defaults.headers.common.Authorization = `Bearer ${token}`;
 };
 
-instance.interceptors.request.use(
-  config => {
-    if (typeof window !== 'undefined') {
+export const clearAuthHeader = () => {
+  delete instance.defaults.headers.common.Authorization;
+};
+
+if (typeof window !== 'undefined') {
+  instance.interceptors.request.use(
+    config => {
       const token =
         useAuthStore.getState().access || localStorage.getItem('access');
       if (!config.headers.Authorization && token) {
         config.headers.Authorization = `Bearer ${token}`;
       }
-    }
-    return config;
-  },
-  error => Promise.reject(error),
-);
 
-if (typeof window !== 'undefined') {
+      return config;
+    },
+    error => Promise.reject(error),
+  );
+
   instance.interceptors.response.use(
     response => response,
-    error => {
-      if (error.response?.status === 401) {
-        // 토큰 재발급 or 로그아웃 로직 추가
+    async error => {
+      const originalRequest = error.config;
+
+      if (error.response?.status === 401 && !originalRequest._retry) {
+        originalRequest._retry = true;
+
+        const newAccessToken = await refreshAccessToken();
+        if (newAccessToken) {
+          setAuthHeader(newAccessToken);
+          originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
+
+          return instance(originalRequest);
+        }
+
+        clearAuthHeader();
+        useAuthStore.getState().clearAuth();
+        localStorage.clear();
         window.location.href = '/login';
       }
       return Promise.reject(error);

--- a/src/api/instance.ts
+++ b/src/api/instance.ts
@@ -42,7 +42,10 @@ if (typeof window !== 'undefined') {
     async error => {
       const originalRequest = error.config;
 
-      if (error.response?.status === 401 && !originalRequest._retry) {
+      if (
+        (error.response?.status === 401 || error.response?.status === 403) &&
+        !originalRequest._retry
+      ) {
         originalRequest._retry = true;
 
         const newAccessToken = await refreshAccessToken();

--- a/src/api/interceptor.ts
+++ b/src/api/interceptor.ts
@@ -8,7 +8,6 @@ export async function refreshAccessToken(): Promise<string | null> {
 
   if (!refresh) {
     clearAuth();
-    window.location.href = '/login';
     return null;
   }
 
@@ -40,8 +39,6 @@ export async function refreshAccessToken(): Promise<string | null> {
   } catch (error) {
     console.error('Failed to refresh token:', error);
     clearAuth();
-    localStorage.clear();
-    window.location.href = '/login';
     return null;
   }
 }

--- a/src/api/interceptor.ts
+++ b/src/api/interceptor.ts
@@ -1,8 +1,9 @@
-import { BASE_URL } from '@/api/instance';
 import { useAuthStore } from '@/store/useAuthStore';
 
+const BASE_URL = 'https://localstorymap.com/api';
+
 // 토큰 갱신 함수
-async function refreshAccessToken(): Promise<string | null> {
+export async function refreshAccessToken(): Promise<string | null> {
   const { refresh, setAuth, clearAuth, user } = useAuthStore.getState();
 
   if (!refresh) {
@@ -50,7 +51,7 @@ export async function apiRequest(
   url: string,
   options: RequestInit = {},
 ): Promise<Response> {
-  const { access, clearAuth } = useAuthStore.getState();
+  const { access } = useAuthStore.getState();
 
   // 첫 번째 시도
   let response = await fetch(url, {

--- a/src/api/interceptor.ts
+++ b/src/api/interceptor.ts
@@ -1,6 +1,5 @@
+import { BASE_URL } from '@/api/instance';
 import { useAuthStore } from '@/store/useAuthStore';
-
-const API_BASE_URL = 'https://localstorymap.com/api';
 
 // 토큰 갱신 함수
 async function refreshAccessToken(): Promise<string | null> {
@@ -13,7 +12,7 @@ async function refreshAccessToken(): Promise<string | null> {
   }
 
   try {
-    const response = await fetch(`${API_BASE_URL}/users/token/refresh/`, {
+    const response = await fetch(`${BASE_URL}/users/token/refresh/`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/src/app/api/login/loginApi.ts
+++ b/src/app/api/login/loginApi.ts
@@ -9,11 +9,11 @@ interface SocialLoginResponse {
     email: string;
     nickname: string;
     provider: string;
-    social_id: string;
-    profile_image?: string;
-    is_paid_user?: boolean;
-    date_joined: string;
-    last_login?: string;
+    socialId: string;
+    profileImage?: string;
+    isPaidUser?: boolean;
+    dateJoined: string;
+    lastLogin?: string;
   };
 }
 

--- a/src/app/api/user/userApi.ts
+++ b/src/app/api/user/userApi.ts
@@ -7,11 +7,11 @@ export interface User {
   email: string;
   nickname: string | null;
   provider: 'google' | 'kakao';
-  social_id: string | null;
-  profile_image: string | null;
-  is_paid_user: boolean;
-  date_joined: string;
-  last_login: string | null;
+  socialId: string | null;
+  profileImage: string | null;
+  isPaidUser: boolean;
+  dateJoined: string;
+  lastLogin: string | null;
 }
 
 // GET - 유저 정보 조회

--- a/src/app/api/user/userApi.ts
+++ b/src/app/api/user/userApi.ts
@@ -1,5 +1,6 @@
 import { ENDPOINTS } from '@/api/endpoints';
-import { useAuthStore } from '@/store/useAuthStore';
+import { BASE_URL } from '@/api/instance';
+import { apiRequest } from '@/api/interceptor';
 
 export interface User {
   id: number;
@@ -13,85 +14,9 @@ export interface User {
   last_login: string | null;
 }
 
-const API_BASE_URL = 'https://localstorymap.com/api';
-
-// 토큰 갱신 함수
-async function refreshAccessToken(): Promise<string | null> {
-  const { refresh, setAuth, clearAuth, user } = useAuthStore.getState();
-
-  if (!refresh) {
-    clearAuth();
-    window.location.href = '/login';
-    return null;
-  }
-
-  try {
-    const response = await fetch(`${API_BASE_URL}/users/token/refresh/`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({ refresh }),
-    });
-
-    if (!response.ok) {
-      throw new Error('Token refresh failed');
-    }
-
-    const data = await response.json();
-    const newAccess = data.access;
-
-    if (user && newAccess) {
-      setAuth(user, newAccess, refresh);
-      localStorage.setItem('access', newAccess);
-      return newAccess;
-    }
-
-    throw new Error('No access token received');
-  } catch (error) {
-    console.error('Failed to refresh token:', error);
-    clearAuth();
-    localStorage.clear();
-    window.location.href = '/login';
-    return null;
-  }
-}
-
-// API 요청 함수
-async function apiRequest(
-  url: string,
-  options: RequestInit = {},
-): Promise<Response> {
-  const { access } = useAuthStore.getState();
-
-  let response = await fetch(url, {
-    ...options,
-    headers: {
-      ...options.headers,
-      Authorization: `Bearer ${access}`,
-    },
-  });
-
-  if (response.status === 401 || response.status === 403) {
-    const newAccess = await refreshAccessToken();
-
-    if (newAccess) {
-      response = await fetch(url, {
-        ...options,
-        headers: {
-          ...options.headers,
-          Authorization: `Bearer ${newAccess}`,
-        },
-      });
-    }
-  }
-
-  return response;
-}
-
 // GET - 유저 정보 조회
 export const getUserInfo = async (): Promise<User> => {
-  const response = await apiRequest(`${API_BASE_URL}${ENDPOINTS.USERS.ME}`, {
+  const response = await apiRequest(`${BASE_URL}${ENDPOINTS.USERS.ME}`, {
     method: 'GET',
   });
 
@@ -107,7 +32,7 @@ export const updateUserNickname = async (nickname: string): Promise<User> => {
   const formData = new FormData();
   formData.append('nickname', nickname);
 
-  const response = await apiRequest(`${API_BASE_URL}${ENDPOINTS.USERS.ME}`, {
+  const response = await apiRequest(`${BASE_URL}${ENDPOINTS.USERS.ME}`, {
     method: 'PATCH',
     body: formData,
   });
@@ -124,7 +49,7 @@ export const updateUserProfileImage = async (file: File): Promise<User> => {
   const formData = new FormData();
   formData.append('profile_image', file);
 
-  const response = await apiRequest(`${API_BASE_URL}${ENDPOINTS.USERS.ME}`, {
+  const response = await apiRequest(`${BASE_URL}${ENDPOINTS.USERS.ME}`, {
     method: 'PATCH',
     body: formData,
   });

--- a/src/components/mypage/MypageProfile.tsx
+++ b/src/components/mypage/MypageProfile.tsx
@@ -30,9 +30,9 @@ export default function MypageProfile() {
     useUserProfile();
 
   const [profileImageUrl, setProfileImageUrl] = useState(
-    '/images/default-userImage.png',
+    profile?.profileImage ?? '/images/default-userImage.png',
   );
-  const [nicknameValue, setNicknameValue] = useState('');
+  const [nicknameValue, setNicknameValue] = useState(profile?.nickname ?? '');
   const [isEditingNickname, setIsEditingNickname] = useState(false);
   const [isUpdating, setIsUpdating] = useState(false);
 
@@ -58,7 +58,7 @@ export default function MypageProfile() {
     const validUserImage = user?.profile_image?.trim();
 
     if (validProfileImage) {
-      setProfileImageUrl(`${validProfileImage}?t=${Date.now()}`);
+      setProfileImageUrl(validProfileImage);
     } else if (validUserImage) {
       setProfileImageUrl(validUserImage);
     } else {

--- a/src/hooks/useUserProfile.ts
+++ b/src/hooks/useUserProfile.ts
@@ -36,7 +36,6 @@ export const useUserProfile = () => {
 
       setProfile(newProfile);
       setAuth(clientUser, access, refresh || '');
-      localStorage.setItem('user', JSON.stringify(clientUser));
     } catch (err) {
       console.error('Failed to fetch user profile:', err);
       setError('프로필 정보를 불러오는데 실패했습니다.');

--- a/src/hooks/useUserProfile.ts
+++ b/src/hooks/useUserProfile.ts
@@ -101,7 +101,7 @@ export const useUserProfile = () => {
         const updatedUser = await updateUserProfileImage(file);
         const updatedClientUser: ClientUser = {
           ...user,
-          profile_image: updatedUser.profile_image || null,
+          profile_image: updatedUser.profileImage || null,
         };
 
         const newProfile = clientUserToProfile(updatedClientUser);
@@ -109,7 +109,7 @@ export const useUserProfile = () => {
         setAuth(updatedClientUser, access, refresh || '');
         localStorage.setItem('user', JSON.stringify(updatedClientUser));
 
-        return updatedUser.profile_image || '';
+        return updatedUser.profileImage || '';
       } catch (err) {
         console.error('Failed to upload profile image:', err);
         throw new Error('프로필 사진 업로드에 실패했습니다.');

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -4,11 +4,11 @@ export interface ApiUser {
   email: string;
   nickname: string | null;
   provider: 'google' | 'kakao';
-  social_id: string | null;
-  profile_image: string | null;
-  is_paid_user: boolean;
-  date_joined: string;
-  last_login: string | null;
+  socialId: string | null;
+  profileImage: string | null;
+  isPaidUser: boolean;
+  dateJoined: string;
+  lastLogin: string | null;
 }
 
 // 클라이언트 상태 관리용 유저 타입
@@ -35,8 +35,8 @@ export const apiUserToClientUser = (apiUser: ApiUser): ClientUser => ({
   email: apiUser.email,
   nickname: apiUser.nickname || '사용자',
   provider: apiUser.provider,
-  profile_image: apiUser.profile_image,
-  is_paid_user: apiUser.is_paid_user,
+  profile_image: apiUser.profileImage,
+  is_paid_user: apiUser.isPaidUser,
 });
 
 export const clientUserToProfile = (user: ClientUser): UserProfile => ({


### PR DESCRIPTION
## 🔗 관련 이슈

Closes #134 

## 📝 작업 목록

- [x] 엑세스 토큰 만료 시 재발급 로직 반영
- [x] user 응답 키 값 API에 맞게 수정

## 🙋‍♀️ 기타 참고사항(선택)

- 리뷰어가 참고하면 좋을 내용이 있다면 적어주세요. (스크린샷, 리뷰 요구사항 등)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 인증 토큰 만료 시 자동으로 토큰을 갱신하고 요청을 재시도하는 기능이 추가되었습니다.

- **버그 수정**
    - 브라우저 환경에서만 인증 관련 인터셉터가 동작하도록 개선되었습니다.
    - 인증 실패 시 로그인 페이지로 안전하게 리다이렉트됩니다.

- **리팩터**
    - 사용자 정보 인터페이스의 속성명이 snake_case에서 camelCase로 표준화되었습니다.
    - 중복된 토큰 관리 및 요청 로직이 중앙 집중식으로 통합되었습니다.
    - 사용자 프로필 이미지 및 닉네임 초기화 로직이 개선되었습니다.
    - 사용자 프로필 이미지 URL에서 불필요한 캐시 무효화 쿼리 파라미터가 제거되었습니다.
    - 사용자 프로필 관련 로컬 저장소 저장 로직이 제거되었습니다.

- **스타일**
    - ESLint 설정이 일부 업데이트되어 코드 스타일 규칙이 강화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->