### PR TITLE
✨  Feat: 게시물 상세 페이지 구현 및 댓글 API 연결

### DIFF
--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -43,11 +43,15 @@ export const ENDPOINTS = {
     LIST: (id: number) => `/stories/${id}/images/`,
   },
   COMMENT: {
-    LIST: (id: number) => `/stories/${id}/comments/`, // get, post
-    DETAIL: (storyId: number, commentId: number) =>
+    LIST: (id: string) => `/stories/${id}/comments/`, // get, post
+    DETAIL: (storyId: string, commentId: string) =>
       `/stories/${storyId}/comments/${commentId}/`, // get, put, delete
     IMAGE: (storyId: number, commentId: number) =>
       `/stories/${storyId}/comments/${commentId}/images/`, // get, post,
+  },
+  COMMENTLIKE: {
+    DETAIL: (storyId: string, commentId: string) =>
+      `/stories/${storyId}/comments/${commentId}/likes/`,
   },
   BOOKMARK: {
     LIST: '/bookmarks/', // get, post

--- a/src/api/options/storyOption.ts
+++ b/src/api/options/storyOption.ts
@@ -51,4 +51,58 @@ export const storyOption = {
       return mutationFetcher('delete', ENDPOINTS.STORYLIKE.LIKE(storyId), {});
     },
   }),
+  postComment: (storyId: string) => ({
+    mutationFn: ({
+      content,
+      parent,
+    }: {
+      content?: string;
+      parent?: number | null;
+    }) => {
+      return mutationFetcher('post', ENDPOINTS.COMMENT.LIST(storyId), {
+        content,
+        parent,
+      });
+    },
+  }),
+  deleteComment: (storyId: string, commentId: string) => ({
+    mutationFn: () => {
+      return mutationFetcher(
+        'delete',
+        ENDPOINTS.COMMENT.DETAIL(storyId, commentId),
+      );
+    },
+  }),
+  patchComment: (storyId: string, commentId: string) => ({
+    mutationFn: ({
+      content,
+      parent,
+    }: {
+      content?: string;
+      parent?: number | null;
+    }) => {
+      return mutationFetcher(
+        'patch',
+        ENDPOINTS.COMMENT.DETAIL(storyId, commentId),
+        {
+          content,
+          parent,
+        },
+      );
+    },
+  }),
+  postCommentLike: (storyId: string, commentId: string) => ({
+    mutationFn: (newLiked: boolean) => {
+      if (newLiked) {
+        return mutationFetcher(
+          'post',
+          ENDPOINTS.COMMENTLIKE.DETAIL(storyId, commentId),
+        );
+      }
+      return mutationFetcher(
+        'delete',
+        ENDPOINTS.COMMENTLIKE.DETAIL(storyId, commentId),
+      );
+    },
+  }),
 };

--- a/src/app/card/page.tsx
+++ b/src/app/card/page.tsx
@@ -88,14 +88,11 @@ function page() {
       <StoryCard
         story={{
           storyId: 'sample-story',
-          images: [
-            '/images/story-sample.png',
-            '/images/story-sample.png',
-            '/images/story-sample.png',
-            '/images/story-sample.png',
-            '/images/story-sample.png',
+          storyImages: [
+            { imageId: 1, imageUrl: '/images/story-sample.png' },
+            { imageId: 2, imageUrl: '/images/story-sample.png' },
           ],
-          userProfile: '/images/default-userImage.png',
+          userProfileImage: '/images/default-userImage.png',
           title: '홍선성현형님 서울 후기',
           content: '사진찍기 좋은 명소!',
           userNickname: '홍선성현님',

--- a/src/components/story/detail/StoryContentActions.tsx
+++ b/src/components/story/detail/StoryContentActions.tsx
@@ -5,7 +5,7 @@ import { Button } from '@components/ui/common/buttons/Button';
 
 import { css } from '@root/styled-system/css';
 
-function StoryContentActions() {
+function StoryContentActions({ isMine }: { isMine: boolean }) {
   return (
     <div
       className={css({
@@ -15,15 +15,38 @@ function StoryContentActions() {
         ml: 'auto',
       })}
     >
-      <Button size="sm" color="outlineSoft">
-        팔로우
+      <Button size="sm" color="outlineSoft" aria-label="팔로우 버튼">
+        Follows
       </Button>
-      <Button size="sm" color="outlineSoft">
-        글수정
-      </Button>
-      <Button size="sm" color="outlineSoft">
-        글삭제
-      </Button>
+      {isMine && (
+        <>
+          <Button
+            size="sm"
+            color="custom"
+            className={css({
+              _hover: {
+                bg: 'blue.50',
+              },
+            })}
+            aria-label="글 수정 버튼"
+          >
+            수정
+          </Button>
+          <Button
+            size="sm"
+            color="custom"
+            className={css({
+              _hover: {
+                bg: 'blue.50',
+                color: 'red',
+              },
+            })}
+            aria-label="글 삭제 버튼"
+          >
+            삭제
+          </Button>
+        </>
+      )}
     </div>
   );
 }

--- a/src/components/story/detail/StoryDetailContent.tsx
+++ b/src/components/story/detail/StoryDetailContent.tsx
@@ -6,6 +6,7 @@ import { ENDPOINTS } from '@api/endpoints';
 import { instance } from '@api/instance';
 import { storyOption } from '@api/options/storyOption';
 import { EyeIcons, HeartIcon } from '@components/icons';
+import CommentSection from '@components/story/detail/comment/CommentSection';
 import UserInfo from '@components/story/detail/UserInfo';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
@@ -34,7 +35,7 @@ function StoryDetailContent({ storyId }: { storyId: string }) {
 
   const mutation = useMutation({
     ...storyOption.postLikeStory(storyId),
-    onMutate: async () => {
+    onMutate: () => {
       queryClient.setQueryData<StoryType>(['storyDetail'], old => {
         if (!old) return old;
         return {
@@ -61,21 +62,24 @@ function StoryDetailContent({ storyId }: { storyId: string }) {
   return (
     <article>
       <div className={css({ mb: 12 })}>
-        <Image
-          src="/images/section.png"
-          alt="StoryDetail"
-          width={1080}
-          height={600}
-          className={css({
-            objectFit: 'cover',
-            width: '100%',
-            height: '500px',
-          })}
-          onError={e => {
-            const target = e.target as HTMLImageElement;
-            target.src = errorDefaultImg;
-          }}
-        />
+        {data?.storyImages.map(image => (
+          <Image
+            key={image.imageId}
+            src={image.imageUrl}
+            alt="StoryDetail"
+            width={1080}
+            height={600}
+            className={css({
+              objectFit: 'cover',
+              width: '100%',
+              height: '100%',
+            })}
+            onError={e => {
+              const target = e.target as HTMLImageElement;
+              target.src = errorDefaultImg;
+            }}
+          />
+        ))}
         <div>
           <p className={css({ mt: 12, mb: 1, textStyle: 'body2' })}>
             {createdAt ? new Date(createdAt).toLocaleDateString() : undefined}
@@ -112,6 +116,7 @@ function StoryDetailContent({ storyId }: { storyId: string }) {
         <EyeIcons aria-label={`조회수 ${viewCount ?? 0}개`} />
         <span>{viewCount ?? 0}</span>
       </div>
+      <CommentSection storyId={storyId} />
     </article>
   );
 }

--- a/src/components/story/detail/StoryDetailContent.tsx
+++ b/src/components/story/detail/StoryDetailContent.tsx
@@ -9,6 +9,8 @@ import { EyeIcons, HeartIcon } from '@components/icons';
 import CommentSection from '@components/story/detail/comment/CommentSection';
 import UserInfo from '@components/story/detail/UserInfo';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Pagination } from 'swiper/modules';
+import { Swiper, SwiperSlide } from 'swiper/react';
 
 import type { StoryType } from '@/types/story.types';
 
@@ -62,24 +64,33 @@ function StoryDetailContent({ storyId }: { storyId: string }) {
   return (
     <article>
       <div className={css({ mb: 12 })}>
-        {data?.storyImages.map(image => (
-          <Image
-            key={image.imageId}
-            src={image.imageUrl}
-            alt="StoryDetail"
-            width={1080}
-            height={600}
-            className={css({
-              objectFit: 'cover',
-              width: '100%',
-              height: '100%',
-            })}
-            onError={e => {
-              const target = e.target as HTMLImageElement;
-              target.src = errorDefaultImg;
-            }}
-          />
-        ))}
+        <Swiper
+          spaceBetween={10}
+          slidesPerView={1.2}
+          modules={[Pagination]}
+          pagination={{ clickable: true }}
+          navigation={false}
+        >
+          {data?.storyImages.map(image => (
+            <SwiperSlide key={image.imageId}>
+              <Image
+                src={image.imageUrl}
+                alt="StoryDetail"
+                width={1080}
+                height={600}
+                className={css({
+                  objectFit: 'cover',
+                  width: '100%',
+                  height: '100%',
+                })}
+                onError={e => {
+                  const target = e.target as HTMLImageElement;
+                  target.src = errorDefaultImg;
+                }}
+              />
+            </SwiperSlide>
+          ))}
+        </Swiper>
         <div>
           <p className={css({ mt: 12, mb: 1, textStyle: 'body2' })}>
             {createdAt ? new Date(createdAt).toLocaleDateString() : undefined}

--- a/src/components/story/detail/UserInfo.tsx
+++ b/src/components/story/detail/UserInfo.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Image from 'next/image';
 import StoryContentActions from '@components/story/detail/StoryContentActions';
+import { useAuthStore } from '@store/useAuthStore';
 
 import { css } from '@root/styled-system/css';
 
@@ -11,28 +12,38 @@ type Props = {
 };
 
 function UserInfo({ createdAt, userNickname, userProfileImage }: Props) {
+  const { user } = useAuthStore();
+  const isMine = user?.nickname === userNickname;
   const defaultUserImage = '/images/default-userImage.png';
 
   return (
     <article>
-      <div className={css({ display: 'flex', gap: 4 })}>
+      <div className={css({ display: 'flex', alignItems: 'center', gap: 4 })}>
         <Image
           src={userProfileImage || defaultUserImage}
           alt="userImage"
           width={40}
           height={40}
+          className={css({ objectFit: 'cover', height: '100%' })}
           onError={e => {
             const target = e.target as HTMLImageElement;
             target.src = defaultUserImage;
           }}
         />
-        <div>
+        <div
+          className={css({
+            fontSize: {
+              base: 'sm',
+              md: 'sm',
+            },
+          })}
+        >
           <p>
             {createdAt ? new Date(createdAt).toLocaleDateString() : undefined}
           </p>
           <p>{userNickname}</p>
         </div>
-        <StoryContentActions />
+        <StoryContentActions isMine={isMine} />
       </div>
     </article>
   );

--- a/src/components/story/detail/UserInfo.tsx
+++ b/src/components/story/detail/UserInfo.tsx
@@ -1,4 +1,6 @@
-import React from 'react';
+'use client';
+
+import React, { useState } from 'react';
 import Image from 'next/image';
 import StoryContentActions from '@components/story/detail/StoryContentActions';
 import { useAuthStore } from '@store/useAuthStore';
@@ -15,20 +17,26 @@ function UserInfo({ createdAt, userNickname, userProfileImage }: Props) {
   const { user } = useAuthStore();
   const isMine = user?.nickname === userNickname;
   const defaultUserImage = '/images/default-userImage.png';
+  const [profileSrc, setProfileSrc] = useState(
+    userProfileImage && userProfileImage.trim() !== ''
+      ? userProfileImage
+      : defaultUserImage,
+  );
 
   return (
     <article>
       <div className={css({ display: 'flex', alignItems: 'center', gap: 4 })}>
         <Image
-          src={userProfileImage || defaultUserImage}
+          src={profileSrc}
           alt="userImage"
           width={40}
           height={40}
-          className={css({ objectFit: 'cover', height: '100%' })}
-          onError={e => {
-            const target = e.target as HTMLImageElement;
-            target.src = defaultUserImage;
-          }}
+          className={css({
+            objectFit: 'cover',
+            height: '100%',
+            borderRadius: 'full',
+          })}
+          onError={() => setProfileSrc(defaultUserImage)}
         />
         <div
           className={css({

--- a/src/components/story/detail/comment/CommentCard.tsx
+++ b/src/components/story/detail/comment/CommentCard.tsx
@@ -196,7 +196,7 @@ function CommentCard({
       {isReplyFormOpen && (
         <CommentForm
           storyId={storyId}
-          mode="replay"
+          mode="reply"
           parentId={comment.commentId}
           targetId={null}
           onCancel={() =>

--- a/src/components/story/detail/comment/CommentCard.tsx
+++ b/src/components/story/detail/comment/CommentCard.tsx
@@ -110,10 +110,8 @@ function CommentCard({
         borderLeft: depth > 0 ? '3px solid #cbd5e1' : 'none',
         maxWidth: { base: 600, sm: '100%' },
         fontSize: { base: 'md', sm: 'sm' },
-      })}
-      style={{
         marginLeft: depth > 0 ? `clamp(8px, ${depth * 20}px, 40px)` : 0,
-      }}
+      })}
     >
       <UserInfo
         createdAt={comment?.createdAt}

--- a/src/components/story/detail/comment/CommentCard.tsx
+++ b/src/components/story/detail/comment/CommentCard.tsx
@@ -1,0 +1,256 @@
+import React, { Dispatch, SetStateAction } from 'react';
+import { storyOption } from '@api/options/storyOption';
+import { HeartIcon } from '@components/icons';
+import CommentForm from '@components/story/detail/comment/CommentForm';
+import UserInfo from '@components/story/detail/UserInfo';
+import { Button } from '@components/ui/common/buttons/Button';
+import { useAuthStore } from '@store/useAuthStore';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { css } from '@root/styled-system/css';
+
+import { CommentStory, InputMode } from '@/types/story.types';
+
+type Props = {
+  comment: CommentStory;
+  allComments: CommentStory[];
+  setMode: Dispatch<SetStateAction<InputMode>>;
+  onEditClick: () => void;
+  onReplyClick: () => void;
+  depth?: number;
+  mode: 'edit' | 'replay' | 'none';
+  modePayload: { targetId: number | null; parent: number | null };
+  storyId: string;
+};
+
+function CommentCard({
+  comment,
+  allComments,
+  setMode,
+  onEditClick,
+  onReplyClick,
+  depth = 0,
+  mode,
+  modePayload,
+  storyId,
+}: Props) {
+  const children = allComments.filter(
+    item => item.parent === comment?.commentId,
+  );
+  const queryClient = useQueryClient();
+  const { user } = useAuthStore();
+  const isMine = user?.nickname === comment.userNickname;
+  const deleteMutation = useMutation({
+    ...storyOption.deleteComment(
+      String(comment?.storyId),
+      String(comment?.commentId),
+    ),
+    onMutate: () => {
+      queryClient.setQueryData<CommentStory[]>(
+        ['comment', String(comment.storyId)],
+        old =>
+          old ? old.filter(item => item.commentId !== comment.commentId) : [],
+      );
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: ['comment', comment?.storyId],
+      });
+    },
+  });
+
+  const mutation = useMutation({
+    ...storyOption.postCommentLike(
+      comment?.storyId,
+      String(comment?.commentId),
+    ),
+    onMutate: () => {
+      queryClient.setQueryData<CommentStory[]>(['comment'], old => {
+        if (!old) return old;
+        return old.map(item =>
+          item?.commentId === comment?.commentId
+            ? {
+                ...item,
+                isLiked: !item.isLiked,
+                likeCount: item.isLiked
+                  ? item.likeCount - 1
+                  : item.likeCount + 1,
+              }
+            : item,
+        );
+      });
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: ['comment', String(comment?.storyId)],
+      });
+    },
+  });
+  const onToggle = (newLiked: boolean) => {
+    mutation.mutate(newLiked);
+  };
+  const onDelete = () => {
+    deleteMutation.mutate();
+  };
+
+  const isReplyFormOpen =
+    mode === 'replay' && modePayload.parent === comment.commentId;
+  const isEditFormOpen =
+    mode === 'edit' && modePayload.targetId === comment.commentId;
+
+  return (
+    <div
+      className={css({
+        mb: 8,
+        mt: 8,
+        p: { base: 4, sm: 2 },
+        borderLeft: depth > 0 ? '3px solid #cbd5e1' : 'none',
+        maxWidth: { base: 600, sm: '100%' },
+        fontSize: { base: 'md', sm: 'sm' },
+      })}
+      style={{
+        marginLeft: depth > 0 ? `clamp(8px, ${depth * 20}px, 40px)` : 0,
+      }}
+    >
+      <UserInfo
+        createdAt={comment?.createdAt}
+        userNickname={comment?.userNickname}
+        userProfileImage={comment?.userProfileImage}
+      />
+      <div className={css({ mb: 2, mt: 2 })}>
+        <p>{comment?.content}</p>
+      </div>
+      <div
+        className={css({
+          borderBottom: '1px solid #c9c9c9',
+          pb: 4,
+          display: 'flex',
+          alignItems: 'center',
+          gap: { base: 4, sm: 2 },
+          fontSize: { base: 'sm', sm: 'sm' },
+        })}
+      >
+        <Button
+          size="sm"
+          onClick={() => onToggle(!comment?.isLiked)}
+          color="custom"
+          disabled={mutation.isPending}
+        >
+          <HeartIcon
+            width={20}
+            height={20}
+            fill={comment?.isLiked ? 'red' : 'none'}
+            aria-label={`좋아요 ${comment?.likeCount ?? 0}개`}
+          />
+        </Button>
+        <span>{comment?.likeCount}</span>
+        {isMine && (
+          <>
+            <Button
+              onClick={onReplyClick}
+              size="sm"
+              className={css({
+                _hover: {
+                  bg: 'blue.50',
+                },
+              })}
+              color="custom"
+              aria-label="댓글 달기"
+            >
+              답글
+            </Button>
+            <Button
+              onClick={onEditClick}
+              size="sm"
+              className={css({
+                _hover: {
+                  bg: 'blue.50',
+                },
+              })}
+              color="custom"
+              aria-label="댓글 수정"
+            >
+              수정
+            </Button>
+            <Button
+              onClick={onDelete}
+              size="sm"
+              className={css({
+                _hover: {
+                  bg: 'blue.50',
+                  color: 'red',
+                },
+              })}
+              disabled={deleteMutation.isPending}
+              color="custom"
+              aria-label="댓글 삭제"
+            >
+              삭제
+            </Button>
+          </>
+        )}
+      </div>
+      {isReplyFormOpen && (
+        <CommentForm
+          storyId={storyId}
+          mode="replay"
+          parentId={comment.commentId}
+          targetId={null}
+          onCancel={() =>
+            setMode({ mode: 'none', payload: { targetId: null, parent: null } })
+          }
+          onSuccess={() =>
+            setMode({ mode: 'none', payload: { targetId: null, parent: null } })
+          }
+        />
+      )}
+      {isEditFormOpen && (
+        <CommentForm
+          storyId={storyId}
+          mode="edit"
+          parentId={null}
+          targetId={comment.commentId}
+          onCancel={() =>
+            setMode({ mode: 'none', payload: { targetId: null, parent: null } })
+          }
+          onSuccess={() =>
+            setMode({ mode: 'none', payload: { targetId: null, parent: null } })
+          }
+        />
+      )}
+      {children.length > 0 &&
+        children.map(item => (
+          <CommentCard
+            key={item.commentId}
+            comment={item}
+            depth={depth + 1}
+            setMode={setMode}
+            allComments={allComments}
+            onEditClick={() =>
+              setMode({
+                mode: 'edit',
+                payload: {
+                  targetId: item?.commentId,
+                  parent: null,
+                },
+              })
+            }
+            onReplyClick={() =>
+              setMode({
+                mode: 'replay',
+                payload: {
+                  targetId: null,
+                  parent: item?.commentId,
+                },
+              })
+            }
+            mode={mode}
+            modePayload={modePayload}
+            storyId={storyId}
+          />
+        ))}
+    </div>
+  );
+}
+
+export default CommentCard;

--- a/src/components/story/detail/comment/CommentCard.tsx
+++ b/src/components/story/detail/comment/CommentCard.tsx
@@ -18,7 +18,7 @@ type Props = {
   onEditClick: () => void;
   onReplyClick: () => void;
   depth?: number;
-  mode: 'edit' | 'replay' | 'none';
+  mode: 'edit' | 'reply' | 'none';
   modePayload: { targetId: number | null; parent: number | null };
   storyId: string;
 };
@@ -65,20 +65,23 @@ function CommentCard({
       String(comment?.commentId),
     ),
     onMutate: () => {
-      queryClient.setQueryData<CommentStory[]>(['comment'], old => {
-        if (!old) return old;
-        return old.map(item =>
-          item?.commentId === comment?.commentId
-            ? {
-                ...item,
-                isLiked: !item.isLiked,
-                likeCount: item.isLiked
-                  ? item.likeCount - 1
-                  : item.likeCount + 1,
-              }
-            : item,
-        );
-      });
+      queryClient.setQueryData<CommentStory[]>(
+        ['comment', String(comment?.storyId)],
+        old => {
+          if (!old) return old;
+          return old.map(item =>
+            item?.commentId === comment?.commentId
+              ? {
+                  ...item,
+                  isLiked: !item.isLiked,
+                  likeCount: item.isLiked
+                    ? item.likeCount - 1
+                    : item.likeCount + 1,
+                }
+              : item,
+          );
+        },
+      );
     },
     onSuccess: async () => {
       await queryClient.invalidateQueries({
@@ -94,7 +97,7 @@ function CommentCard({
   };
 
   const isReplyFormOpen =
-    mode === 'replay' && modePayload.parent === comment.commentId;
+    mode === 'reply' && modePayload.parent === comment.commentId;
   const isEditFormOpen =
     mode === 'edit' && modePayload.targetId === comment.commentId;
 
@@ -237,7 +240,7 @@ function CommentCard({
             }
             onReplyClick={() =>
               setMode({
-                mode: 'replay',
+                mode: 'reply',
                 payload: {
                   targetId: null,
                   parent: item?.commentId,

--- a/src/components/story/detail/comment/CommentForm.tsx
+++ b/src/components/story/detail/comment/CommentForm.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { storyOption } from '@api/options/storyOption';
 import { Button } from '@components/ui/common/buttons/Button';
 import { Input } from '@components/ui/common/textfields';
@@ -12,7 +12,7 @@ import { InputMode } from '@/types/story.types';
 
 type Props = {
   storyId: string;
-  mode: 'edit' | 'replay' | 'none';
+  mode: 'edit' | 'reply' | 'none';
   parentId: number | null;
   targetId: number | null;
   onCancel?: () => void;
@@ -105,7 +105,7 @@ function CommentForm({
       >
         등록
       </Button>
-      {onCancel && (mode === 'edit' || mode === 'replay') && (
+      {onCancel && (mode === 'edit' || mode === 'reply') && (
         <Button
           type="button"
           color="outlineSoft"

--- a/src/components/story/detail/comment/CommentForm.tsx
+++ b/src/components/story/detail/comment/CommentForm.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import { storyOption } from '@api/options/storyOption';
+import { Button } from '@components/ui/common/buttons/Button';
+import { Input } from '@components/ui/common/textfields';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { css } from '@root/styled-system/css';
+
+import { InputMode } from '@/types/story.types';
+
+type Props = {
+  storyId: string;
+  mode: 'edit' | 'replay' | 'none';
+  parentId: number | null;
+  targetId: number | null;
+  onCancel?: () => void;
+  onSuccess?: () => void;
+};
+
+function CommentForm({
+  storyId,
+  mode,
+  parentId,
+  targetId,
+  onCancel,
+  onSuccess,
+}: Props) {
+  const INITIAL_INPUT_MODE: InputMode = {
+    mode,
+    payload: {
+      targetId: targetId ?? null,
+      parent: parentId ?? null,
+      content: '',
+    },
+  };
+  const queryClient = useQueryClient();
+  const [value, setValue] = useState(INITIAL_INPUT_MODE);
+  const mutation = useMutation({
+    ...(mode === 'edit'
+      ? storyOption.patchComment(storyId, String(targetId))
+      : storyOption.postComment(storyId)),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ['comment', storyId] });
+      if (onSuccess) onSuccess();
+    },
+  });
+
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setValue(prev => ({
+      ...prev,
+      payload: {
+        ...prev.payload,
+        content: e.target.value,
+      },
+    }));
+  };
+
+  const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (mode === 'edit') {
+      mutation.mutate({
+        content: value.payload.content ?? '',
+      });
+    } else {
+      mutation.mutate({
+        content: value.payload.content ?? '',
+        parent: value.payload.parent,
+      });
+    }
+    setValue(INITIAL_INPUT_MODE);
+  };
+  return (
+    <form
+      onSubmit={onSubmit}
+      className={css({
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        mb: 24,
+      })}
+    >
+      <Input
+        name="content"
+        value={value.payload.content ?? ''}
+        placeholder="댓글을 입력하세요..."
+        onChange={onChange}
+      />
+      <Button
+        type="submit"
+        color="custom"
+        disabled={!value.payload.content?.trim()}
+        aria-label="댓글 등록"
+        className={css({
+          width: '20%',
+          px: '20px',
+          py: '18px',
+          _hover: {
+            bg: 'blue.50',
+            px: '20px',
+            py: '18px',
+          },
+        })}
+      >
+        등록
+      </Button>
+      {onCancel && (mode === 'edit' || mode === 'replay') && (
+        <Button
+          type="button"
+          color="outlineSoft"
+          onClick={onCancel}
+          className={css({ ml: 2 })}
+        >
+          취소
+        </Button>
+      )}
+    </form>
+  );
+}
+
+export default CommentForm;

--- a/src/components/story/detail/comment/CommentSection.tsx
+++ b/src/components/story/detail/comment/CommentSection.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import React, { useState } from 'react';
+import { ENDPOINTS } from '@api/endpoints';
+import { instance } from '@api/instance';
+import CommentCard from '@components/story/detail/comment/CommentCard';
+import CommentForm from '@components/story/detail/comment/CommentForm';
+import { useQuery } from '@tanstack/react-query';
+
+import { CommentStory } from '@/types/story.types';
+
+export type InputMode = {
+  mode: 'edit' | 'replay' | 'none';
+  payload: {
+    targetId: number | null;
+    parent: number | null;
+  };
+};
+
+function CommentSection({ storyId }: { storyId: string }) {
+  const { data, isLoading, isError } = useQuery<CommentStory[]>({
+    queryKey: ['comment', storyId],
+    queryFn: () =>
+      instance.get(ENDPOINTS.COMMENT.LIST(storyId)).then(res => res.data),
+  });
+  const [mode, setMode] = useState<InputMode>({
+    mode: 'none',
+    payload: {
+      targetId: null,
+      parent: null,
+    },
+  });
+  const rootComment = data?.filter(comment => !comment.parent);
+  if (isLoading) return <p>Loading...</p>;
+  if (isError) return <p>Error...</p>;
+
+  return (
+    <div>
+      {data &&
+        data.length > 0 &&
+        rootComment?.map(comment => (
+          <CommentCard
+            key={comment.commentId}
+            allComments={data}
+            comment={comment}
+            setMode={setMode}
+            onEditClick={() =>
+              setMode({
+                mode: 'edit',
+                payload: {
+                  targetId: comment.commentId,
+                  parent: null,
+                },
+              })
+            }
+            onReplyClick={() =>
+              setMode({
+                mode: 'replay',
+                payload: {
+                  targetId: null,
+                  parent:
+                    comment.parent !== null
+                      ? comment.parent
+                      : comment.commentId,
+                },
+              })
+            }
+            mode={mode.mode}
+            modePayload={mode.payload}
+            storyId={storyId}
+          />
+        ))}
+      <CommentForm
+        key={`${mode.mode}-${mode.payload.targetId}-${mode.payload.parent}`}
+        storyId={storyId}
+        mode="none"
+        parentId={null}
+        targetId={null}
+      />
+    </div>
+  );
+}
+
+export default CommentSection;

--- a/src/components/story/detail/comment/CommentSection.tsx
+++ b/src/components/story/detail/comment/CommentSection.tsx
@@ -7,15 +7,7 @@ import CommentCard from '@components/story/detail/comment/CommentCard';
 import CommentForm from '@components/story/detail/comment/CommentForm';
 import { useQuery } from '@tanstack/react-query';
 
-import { CommentStory } from '@/types/story.types';
-
-export type InputMode = {
-  mode: 'edit' | 'replay' | 'none';
-  payload: {
-    targetId: number | null;
-    parent: number | null;
-  };
-};
+import type { CommentStory, InputMode } from '@/types/story.types';
 
 function CommentSection({ storyId }: { storyId: string }) {
   const { data, isLoading, isError } = useQuery<CommentStory[]>({
@@ -55,7 +47,7 @@ function CommentSection({ storyId }: { storyId: string }) {
             }
             onReplyClick={() =>
               setMode({
-                mode: 'replay',
+                mode: 'reply',
                 payload: {
                   targetId: null,
                   parent:

--- a/src/components/story/sections/StoryCardListSection.tsx
+++ b/src/components/story/sections/StoryCardListSection.tsx
@@ -44,9 +44,10 @@ function StoryCardListSection() {
       className={css({
         display: 'flex',
         flexDirection: 'column',
-        alignItems: 'center',
-        gap: 4,
+        gap: 8,
         mt: 12,
+        width: '100%',
+        margin: '0 auto',
       })}
     >
       {storyList && storyList?.length > 0 ? (

--- a/src/components/story/sections/StorySearchSection.tsx
+++ b/src/components/story/sections/StorySearchSection.tsx
@@ -9,7 +9,7 @@ function StorySearchSection() {
   return (
     <article className={css({ mt: 24 })}>
       <div>
-        <Search />
+        <Search placeholder="유저 이름을 검색해주세요..." />
       </div>
     </article>
   );

--- a/src/components/ui/common/cards/StoryCard.tsx
+++ b/src/components/ui/common/cards/StoryCard.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import React, { useState } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
 import { storyOption } from '@api/options/storyOption';
@@ -16,8 +17,6 @@ import {
 } from '@/components/ui/common/cards/card.recipe';
 import type { StoryCardProps, StoryQueryData } from '@/types/story.types';
 
-import defaultUserProfile from '@images/default-userImage.png';
-
 import { css, cx } from '@root/styled-system/css';
 
 function StoryCard({ story }: StoryCardProps) {
@@ -30,7 +29,7 @@ function StoryCard({ story }: StoryCardProps) {
     userNickname,
     createdAt,
     storyImages = [],
-    userProfile,
+    userProfileImage,
     title,
     content,
   } = story;
@@ -68,7 +67,12 @@ function StoryCard({ story }: StoryCardProps) {
     if (newLiked === undefined) return;
     mutation.mutate(newLiked);
   };
-
+  const defaultUserImage = '/images/default-userImage.png';
+  const [profileSrc, setProfileSrc] = useState(
+    userProfileImage && userProfileImage.trim() !== ''
+      ? userProfileImage
+      : defaultUserImage,
+  );
   const images = storyImages.map(img => img.imageUrl);
   const imageCount = images.length;
   const layout = String(Math.max(1, Math.min(imageCount, 5)));
@@ -158,7 +162,15 @@ function StoryCard({ story }: StoryCardProps) {
             overflow: 'hidden',
           })}
         >
-          <Image src={userProfile || defaultUserProfile} alt="프로필" fill />
+          <Image
+            src={profileSrc}
+            alt="프로필"
+            fill
+            onError={() => {
+              console.log('onError triggered for:', profileSrc);
+              setProfileSrc(defaultUserImage);
+            }}
+          />
         </div>
 
         <div className={cx(css({ mt: 8, pl: '4' }))}>

--- a/src/components/ui/common/cards/StoryCard.tsx
+++ b/src/components/ui/common/cards/StoryCard.tsx
@@ -29,7 +29,7 @@ function StoryCard({ story }: StoryCardProps) {
     isLiked,
     userNickname,
     createdAt,
-    images,
+    storyImages = [],
     userProfile,
     title,
     content,
@@ -60,7 +60,7 @@ function StoryCard({ story }: StoryCardProps) {
       });
     },
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: ['story'] });
+      await queryClient.invalidateQueries({ queryKey: ['story', storyId] });
     },
   });
 
@@ -69,7 +69,8 @@ function StoryCard({ story }: StoryCardProps) {
     mutation.mutate(newLiked);
   };
 
-  const imageCount = images?.length ?? 0;
+  const images = storyImages.map(img => img.imageUrl);
+  const imageCount = images.length;
   const layout = String(Math.max(1, Math.min(imageCount, 5)));
 
   return (
@@ -82,34 +83,69 @@ function StoryCard({ story }: StoryCardProps) {
         p: 'none',
         radius: 'sm',
       })}
+      style={{ width: '100%' }}
     >
-      <Link href={`/story/${storyId}`} passHref>
-        <div
-          className={gridImageWrapper({
-            layout: layout as '1' | '2' | '3' | '4' | '5',
-          })}
-        >
-          {images?.slice(0, 5).map((src, i) => (
-            <div
-              key={i}
-              className={css({
-                position: 'relative',
-                ...(i === 0 && layout === '5' ? { gridRow: 'span 2' } : {}),
-              })}
-            >
-              <Image
-                src={src}
-                alt={`스토리 이미지 ${i + 1}`}
-                fill
-                className={cardImage()}
-                onError={e => {
-                  const target = e.target as HTMLImageElement;
-                  target.src = errorDefaultImg;
-                }}
-              />
-            </div>
-          ))}
-        </div>
+      <Link
+        href={`/story/${storyId}`}
+        passHref
+        aria-label="글 상세 이동 버튼"
+        className={css({ width: '100%' })}
+      >
+        {imageCount === 1 || imageCount === 0 ? (
+          <div
+            style={{
+              width: '100%',
+              height: '200px',
+              position: 'relative',
+              overflow: 'hidden',
+              borderRadius: 8,
+            }}
+          >
+            <Image
+              src={imageCount === 1 ? images[0] : errorDefaultImg}
+              alt="스토리 이미지"
+              fill
+              style={{
+                objectFit: 'cover',
+                width: '100%',
+                height: '100%',
+                display: 'block',
+              }}
+              onError={e => {
+                const target = e.target as HTMLImageElement;
+                target.src = errorDefaultImg;
+              }}
+            />
+          </div>
+        ) : (
+          <div
+            className={gridImageWrapper({
+              layout: layout as '2' | '3' | '4' | '5',
+            })}
+            style={{ width: '100%', height: '200px', position: 'relative' }}
+          >
+            {images.slice(0, 5).map((src, i) => (
+              <div
+                key={i}
+                className={css({
+                  position: 'relative',
+                  ...(i === 0 && layout === '5' ? { gridRow: 'span 2' } : {}),
+                })}
+              >
+                <Image
+                  src={src}
+                  alt={`스토리 이미지 ${i + 1}`}
+                  fill
+                  className={cardImage()}
+                  onError={e => {
+                    const target = e.target as HTMLImageElement;
+                    target.src = errorDefaultImg;
+                  }}
+                />
+              </div>
+            ))}
+          </div>
+        )}
 
         <div
           className={css({

--- a/src/types/story.types.ts
+++ b/src/types/story.types.ts
@@ -55,7 +55,7 @@ export type CommentStory = {
 };
 
 export type InputMode = {
-  mode: 'edit' | 'replay' | 'none';
+  mode: 'edit' | 'reply' | 'none';
   payload: {
     content?: string;
     targetId: number | null;

--- a/src/types/story.types.ts
+++ b/src/types/story.types.ts
@@ -1,3 +1,8 @@
+type StoryImageType = {
+  imageUrl: string;
+  imageId: number;
+};
+
 export type StoryType = {
   createdAt: string;
   title: string;
@@ -7,12 +12,13 @@ export type StoryType = {
   isLiked: boolean;
   likeCount: number;
   viewCount: number;
+  storyImages: StoryImageType[];
 };
 
 export type StoryCardProps = {
   story: {
     storyId: string;
-    images?: string[];
+    storyImages: StoryImageType[];
     userProfile?: string;
     title: string;
     content: string;
@@ -33,4 +39,26 @@ type StoryPage = {
 export type StoryQueryData = {
   pages: StoryPage[];
   pageParams: unknown[];
+};
+
+export type CommentStory = {
+  commentId: number | null;
+  content: string;
+  createdAt: string;
+  isLiked: boolean;
+  likeCount: number;
+  storyId: string;
+  parent: number | null;
+  updatedAt: string;
+  userNickname: string;
+  userProfileImage: string;
+};
+
+export type InputMode = {
+  mode: 'edit' | 'replay' | 'none';
+  payload: {
+    content?: string;
+    targetId: number | null;
+    parent: number | null;
+  };
 };

--- a/src/types/story.types.ts
+++ b/src/types/story.types.ts
@@ -19,7 +19,7 @@ export type StoryCardProps = {
   story: {
     storyId: string;
     storyImages: StoryImageType[];
-    userProfile?: string;
+    userProfileImage?: string;
     title: string;
     content: string;
     likeCount?: number;


### PR DESCRIPTION
## 🔗 관련 이슈

- 이 PR이 해결하는 이슈 번호를 명시해주세요.
- Close #137 

## 📝 작업 목록

- [ ] 댓글 API 연동 및 정상 동작 테스트
- [ ]  이미지 스와이프 기능 적용
- [ ] 작성자 본인만 댓글과 스토리 삭제 및 수정 가능하도록 처리

## 🙋‍♀️ 기타 참고사항(선택)

- 리뷰어가 참고하면 좋을 내용이 있다면 적어주세요. (스크린샷, 리뷰 요구사항 등)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 댓글 작성, 수정, 삭제, 답글, 좋아요 토글 등 댓글 관련 기능이 추가되었습니다.
  - 스토리 상세 페이지에 댓글 섹션이 추가되어 댓글 목록 및 입력이 가능합니다.
  - 여러 이미지를 슬라이드로 볼 수 있는 이미지 캐러셀 기능이 스토리 상세에 적용되었습니다.

- **버그 수정**
  - 좋아요 토글 시 카운트가 올바르게 증가/감소하도록 수정되었습니다.

- **개선 및 스타일**
  - 프로필 이미지 로딩 실패 시 기본 이미지로 대체하는 처리가 추가되었습니다.
  - 스토리 카드 및 상세 페이지의 레이아웃과 이미지 표시 방식이 개선되었습니다.
  - 접근성을 위한 aria-label 속성이 버튼 등에 추가되었습니다.
  - 버튼 및 컨테이너 스타일이 전반적으로 개선되었습니다.

- **기타**
  - 스토리, 댓글, 이미지 관련 타입이 명확하게 정의 및 개선되었습니다.
  - 검색 입력창에 플레이스홀더가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->