### PR TITLE
✨ Feat: 마이페이지 마이스토리 페이지 구현

### DIFF
--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -33,6 +33,7 @@ export const ENDPOINTS = {
   },
   STORY: {
     LIST: '/stories/', // get, post
+    ME: '/stories/me/',
     MARKER: (id: number) => `/stories/marker/${id}/`,
     DETAIL: (id: string) => `/stories/${id}/`, // get, put, delete
   },

--- a/src/api/options/storyOption.ts
+++ b/src/api/options/storyOption.ts
@@ -51,6 +51,31 @@ export const storyOption = {
       return mutationFetcher('delete', ENDPOINTS.STORYLIKE.LIKE(storyId), {});
     },
   }),
+  patchStory: () => ({
+    mutationFn: async ({
+      storyId,
+      story,
+      images,
+    }: PostStoryPayload & { storyId: number }) => {
+      const storyRes = await mutationFetcher(
+        'patch',
+        ENDPOINTS.STORY.DETAIL(String(storyId)),
+        story,
+      );
+
+      // 이미지 추가 업로드 있을 때만
+      if (images && images.length > 0) {
+        const formData = new FormData();
+        formData.append('story_id', String(storyId));
+        images.forEach(image => formData.append('image_file', image));
+        await instance.post(ENDPOINTS.STORY_IMAGE.UPLOAD(storyId), formData, {
+          headers: { 'Content-Type': undefined },
+        });
+      }
+
+      return storyRes;
+    },
+  }),
   postComment: (storyId: string) => ({
     mutationFn: ({
       content,

--- a/src/app/api/story/storyApi.ts
+++ b/src/app/api/story/storyApi.ts
@@ -4,6 +4,7 @@ import { Story } from '@/types/story';
 
 export const getMyStories = (page: number = 1) => {
   return queryFetcher<{ results: Story[]; next?: string | null }>(
-    `${ENDPOINTS.STORY.ME}?page=${page}`,
+    ENDPOINTS.STORY.ME,
+    { page },
   );
 };

--- a/src/app/api/story/storyApi.ts
+++ b/src/app/api/story/storyApi.ts
@@ -1,0 +1,9 @@
+import { ENDPOINTS } from '@/api/endpoints';
+import { queryFetcher } from '@/api/fetcher';
+import { Story } from '@/types/story';
+
+export const getMyStories = (page: number = 1) => {
+  return queryFetcher<{ results: Story[]; next?: string | null }>(
+    `${ENDPOINTS.STORY.ME}?page=${page}`,
+  );
+};

--- a/src/app/mypage/feelings/layout.tsx
+++ b/src/app/mypage/feelings/layout.tsx
@@ -1,0 +1,15 @@
+import { mypageContainer } from '@/components/mypage/mypage.recipe';
+import PageHeader from '@/components/ui/common/pageHeader/PageHeader';
+
+export default function StoryLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <>
+      <PageHeader title="내가 쓴 스토리" />
+      <div className={mypageContainer()}>{children}</div>
+    </>
+  );
+}

--- a/src/app/mypage/feelings/page.tsx
+++ b/src/app/mypage/feelings/page.tsx
@@ -1,0 +1,174 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+import { getMyStories } from '@/app/api/story/storyApi';
+import { Button } from '@/components/ui/common/buttons/Button';
+import WideCard from '@/components/ui/common/cards/WideCard';
+import WideCardContent from '@/components/ui/common/cards/WideCardContent';
+import { Story } from '@/types/story';
+
+import { css } from '@root/styled-system/css';
+
+export default function MyStoryPage() {
+  const router = useRouter();
+  const [stories, setStories] = useState<Story[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [page, setPage] = useState(1);
+  const [hasNext, setHasNext] = useState(false);
+
+  const fetchStories = useCallback(async () => {
+    try {
+      setLoading(true);
+      const fetchFunction = getMyStories(page);
+      const response = await fetchFunction();
+
+      let storyData: Story[] = [];
+      let next = false;
+      if (Array.isArray(response)) {
+        storyData = response;
+      } else if (response && 'results' in response) {
+        storyData = response.results || [];
+        next = !!response.next;
+      }
+
+      if (page === 1) {
+        setStories(storyData);
+      } else {
+        setStories(prev => [...prev, ...storyData]);
+      }
+      setHasNext(next);
+    } catch (error) {
+      if (process.env.NODE_ENV === 'development') {
+        // eslint-disable-next-line no-console
+        console.error('스토리 불러오기 실패:', error);
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [page]);
+
+  useEffect(() => {
+    fetchStories();
+  }, [fetchStories]);
+
+  const handleEditClick = (storyId: number) => {
+    router.push(`/story/post/${storyId}`);
+  };
+
+  const handleCardClick = (storyId: number) => {
+    router.push(`/story/${storyId}`);
+  };
+
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString);
+    return date
+      .toLocaleDateString('ko-KR', {
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+      })
+      .replace(/\. /g, '. ')
+      .replace(/\.$/, '');
+  };
+
+  if (loading && page === 1) {
+    return (
+      <div
+        className={css({
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          height: '400px',
+        })}
+      >
+        <p className={css({ textStyle: 'body2', color: 'gray.500' })}>
+          로딩 중...
+        </p>
+      </div>
+    );
+  }
+
+  if (stories.length === 0 && !loading) {
+    return (
+      <div
+        className={css({
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'center',
+          alignItems: 'center',
+          height: '400px',
+          gap: '16px',
+        })}
+      >
+        <p className={css({ textStyle: 'body2', color: 'gray.500' })}>
+          아직 작성한 스토리가 없습니다.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className={css({ width: '100%' })}>
+      <div
+        className={css({
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '16px',
+        })}
+      >
+        {stories.map(story => {
+          const firstImage =
+            story.storyImages?.[0]?.imageUrl || '/images/default-thumbnail.png';
+          const storyDate = formatDate(story.createdAt);
+
+          return (
+            <WideCard key={story.storyId} image={firstImage}>
+              <WideCardContent
+                title={story.title}
+                subtitle={storyDate}
+                date
+                footerType="feeling"
+                footerText={story.emoji}
+                action={
+                  <Button
+                    color="primary"
+                    size="sm"
+                    radius="sm"
+                    onClick={e => {
+                      e.stopPropagation();
+                      handleEditClick(story.storyId);
+                    }}
+                  >
+                    Edit
+                  </Button>
+                }
+                onClick={() => handleCardClick(story.storyId)}
+              />
+            </WideCard>
+          );
+        })}
+      </div>
+      {hasNext && (
+        <div
+          className={css({
+            display: 'flex',
+            justifyContent: 'center',
+            marginTop: '24px',
+          })}
+        >
+          <Button
+            color="black"
+            size="sm"
+            radius="sm"
+            onClick={() => setPage(prev => prev + 1)}
+            disabled={loading}
+          >
+            {loading ? '로딩 중...' : '더보기'}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/story/post/[storyId]/page.tsx
+++ b/src/app/story/post/[storyId]/page.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useParams } from 'next/navigation';
+
+import { ENDPOINTS } from '@/api/endpoints';
+import { ssrFetcher } from '@/api/fetcher';
+import StoryPostForm from '@/components/story/StoryPostForm';
+
+function EditStoryPage() {
+  const params = useParams();
+  const storyId = params?.storyId as string | undefined;
+  const [initialData, setInitialData] = useState<any>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!storyId) return;
+    async function fetchStory() {
+      setLoading(true);
+      try {
+        const data = await ssrFetcher(ENDPOINTS.STORY.DETAIL(String(storyId)));
+        setInitialData({
+          marker: data.marker,
+          title: data.title,
+          content: data.content,
+          emoji: data.emoji,
+          storyImages: data.storyImages,
+        });
+      } finally {
+        setLoading(false);
+      }
+    }
+    fetchStory();
+  }, [storyId]);
+
+  if (loading) return <div>로딩 중...</div>;
+  if (!initialData) return null;
+
+  return <StoryPostForm initialData={initialData} storyId={Number(storyId)} />;
+}
+
+export default EditStoryPage;

--- a/src/app/story/post/[storyId]/page.tsx
+++ b/src/app/story/post/[storyId]/page.tsx
@@ -6,11 +6,18 @@ import { useParams } from 'next/navigation';
 import { ENDPOINTS } from '@/api/endpoints';
 import { ssrFetcher } from '@/api/fetcher';
 import StoryPostForm from '@/components/story/StoryPostForm';
+import { StoryImage } from '@/types/story';
 
 function EditStoryPage() {
   const params = useParams();
   const storyId = params?.storyId as string | undefined;
-  const [initialData, setInitialData] = useState<any>(null);
+  const [initialData, setInitialData] = useState<{
+    marker: number | null;
+    title: string;
+    content: string;
+    emoji: string;
+    storyImages?: StoryImage[];
+  } | null>(null);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {

--- a/src/components/mypage/MypageMenuList.tsx
+++ b/src/components/mypage/MypageMenuList.tsx
@@ -37,25 +37,25 @@ export default function MypageMenuList() {
     {
       title: '북마크',
       icon: BookmarkIcon,
-      route: '/bookmarks',
+      route: '/mypage/bookmarks',
       colorMode: 'stroke',
     },
     {
       title: 'Feelings and Thoughts',
       icon: TravelIcon,
-      route: '/feelings',
+      route: '/mypage/feelings',
       colorMode: 'stroke',
     },
     {
       title: '구독',
       icon: VersionIcon,
-      route: '/subscribe',
+      route: '/mypage/subscribe',
       colorMode: 'stroke',
     },
     {
       title: '설정',
       icon: SettingsIcon,
-      route: '/settings',
+      route: '/mypage/settings',
       colorMode: 'fill',
     },
     {

--- a/src/components/story/StoryPostForm.tsx
+++ b/src/components/story/StoryPostForm.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { gridLayout } from '@components/map/map.recipe';
 import StoryPostPlace from '@components/story/sections/StoryPostPlace';
@@ -14,7 +14,7 @@ import { useMutation } from '@tanstack/react-query';
 import { storyOption } from '@/api/options/storyOption';
 import FileUploadButton from '@/components/ui/maps/FileUploadButton';
 import { FEELINGS } from '@/constants/story';
-import { PostStoryPayload } from '@/types/story';
+import { PostStoryPayload, StoryImage } from '@/types/story';
 import {
   getDayOptions,
   getMonthOptions,
@@ -24,28 +24,56 @@ import {
 
 import { css } from '@root/styled-system/css';
 
-function StoryPostForm() {
-  const router = useRouter();
+type Props = {
+  initialData?: {
+    marker: number | null;
+    title: string;
+    content: string;
+    emoji: string;
+    storyImages?: StoryImage[];
+  };
+  storyId?: number;
+};
 
+function StoryPostForm({ initialData, storyId }: Props) {
+  const router = useRouter();
   const [date, setDate] = useState(getToday());
 
   const renderedFeelings = FEELINGS.map(({ label: Icon, value }) => ({
     label: <Icon />,
     value,
   }));
-  const [feeling, setFeeling] = useState('smile');
 
-  const [marker, setMarker] = useState<number | null>(null);
-  const [title, setTitle] = useState('');
-  const [content, setContent] = useState('');
+  const [marker, setMarker] = useState<number | null>(
+    initialData?.marker ?? null,
+  );
+  const [title, setTitle] = useState(initialData?.title ?? '');
+  const [content, setContent] = useState(initialData?.content ?? '');
+  const [feeling, setFeeling] = useState(initialData?.emoji ?? 'smile');
+  // 신규로 추가하는 이미지 (파일 객체만 관리)
   const [images, setImages] = useState<File[]>([]);
+  // 기존에 등록된 이미지 (수정 시 미리보기 용도)
+  const [originImages] = useState<StoryImage[]>(initialData?.storyImages ?? []);
 
-  const { mutate } = useMutation({
-    ...storyOption.postStory(),
+  // 신규 작성
+  const postMutation = useMutation({
+    mutationFn: storyOption.postStory().mutationFn,
+    onSuccess: () => router.push('/story'),
+  });
+  // 수정
+  const patchMutation = useMutation({
+    mutationFn: storyOption.patchStory().mutationFn,
     onSuccess: () => {
-      router.push('/story');
+      router.push(`/story/${storyId}`);
     },
   });
+  useEffect(() => {
+    if (!initialData) return;
+    setMarker(initialData.marker ?? null);
+    setTitle(initialData.title ?? '');
+    setContent(initialData.content ?? '');
+    setFeeling(initialData.emoji ?? 'smile');
+  }, [initialData]);
 
   const onSubmit = () => {
     const payload: PostStoryPayload = {
@@ -57,13 +85,19 @@ function StoryPostForm() {
       },
       images,
     };
-    mutate(payload);
+    if (storyId) {
+      patchMutation.mutate({ ...payload, storyId });
+    } else {
+      postMutation.mutate(payload);
+    }
   };
 
   return (
     <div className={flex({ gap: 'xl', marginB: 'sm' })}>
       <div className={flex({ gap: 'lg', p: 'sm', marginB: 'sm' })}>
-        <p className={modalText({ text: 'head4', align: 'left' })}>글작성</p>
+        <p className={modalText({ text: 'head4', align: 'left' })}>
+          {storyId ? '글 수정' : '글작성'}
+        </p>
         <StoryPostPlace setMarker={setMarker} />
         <div className={flex({ direction: 'row', gap: 'md' })}>
           <FilterDropdown
@@ -116,6 +150,20 @@ function StoryPostForm() {
             fontWeight: '400',
           })}
         />
+        {/* 기존 이미지 미리보기 */}
+        {originImages.length > 0 && (
+          <div className={gridLayout({ columns: 3, p: 'xs', gap: 'sm' })}>
+            {originImages.map((img, idx) => (
+              <img
+                key={img.imageId}
+                src={img.imageUrl}
+                alt={`업로드 이미지 ${idx + 1}`}
+                style={{ width: '100%', objectFit: 'cover', borderRadius: 8 }}
+              />
+            ))}
+          </div>
+        )}
+        {/* 새로 업로드하는 이미지 */}
         <FileUploadButton setImages={setImages} />
         <div className={gridLayout({ columns: 3, p: 'xs', gap: 'sm' })}>
           {images.map((file, idx) => (
@@ -131,8 +179,12 @@ function StoryPostForm() {
           ))}
         </div>
       </div>
-      <Button onClick={onSubmit} color="black">
-        작성 완료
+      <Button
+        onClick={onSubmit}
+        color="black"
+        disabled={postMutation.isPending || patchMutation.isPending}
+      >
+        {storyId ? '수정 완료' : '작성 완료'}
       </Button>
     </div>
   );

--- a/src/types/story.ts
+++ b/src/types/story.ts
@@ -21,6 +21,7 @@ export type Story = {
   createdAt: string;
   updatedAt: string;
   isLiked: boolean;
+  storyImages?: StoryImage[];
 };
 
 export type StoryImage = {


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #142 

## 📝 작업 목록
- [x] 마이 스토리 페이지 마크업 및 카드 리스트 렌더링 (스토리 없을 시 빈 상태 UI 포함)
- [x] 스토리 API 연동 및 카드 렌더링 (수정 버튼 포함)
- [x] 스토리 작성/수정 분기 처리

## 🙋‍♀️ 기타 참고사항(선택)
![screencapture-localhost-3000-mypage-feelings-2025-06-23-19_55_51](https://github.com/user-attachments/assets/54b69df7-4f23-4bf2-8544-26589e0ff5b0)
![screencapture-localhost-3000-mypage-feelings-2025-06-23-19_51_44](https://github.com/user-attachments/assets/2f4b5b33-8cff-4795-895b-a7112b02aed7)
![screencapture-localhost-3000-story-post-18-2025-06-23-19_54_10](https://github.com/user-attachments/assets/d8711c5b-3174-47f4-8217-b0583bc7715d)
![screencapture-localhost-3000-story-18-2025-06-23-19_54_31](https://github.com/user-attachments/assets/efcb6fce-dc16-48a9-92ff-675c3e8be0a0)
![image](https://github.com/user-attachments/assets/bdcf5d7f-aebe-4ee4-ac3a-b1ca0f9058f7)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 마이페이지에서 내가 쓴 스토리 목록을 확인하고, 페이지네이션 및 "더 보기" 기능을 통해 추가 스토리를 불러올 수 있습니다.
  - 스토리 카드에서 "수정" 버튼을 통해 스토리 편집 페이지로 바로 이동할 수 있습니다.
  - 스토리 작성 폼이 신규 작성과 기존 스토리 편집 모두를 지원하며, 편집 시 기존 이미지와 새로 업로드한 이미지를 미리보기로 확인할 수 있습니다.
  - 내 스토리 전용 API 호출과 스토리 부분 수정 기능이 추가되었습니다.
  - 스토리 편집 페이지가 새롭게 도입되어 기존 스토리 내용을 불러와 수정할 수 있습니다.

- **개선 사항**
  - 마이페이지 메뉴 경로가 "/mypage"로 통일되어 접근성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->