### PR TITLE
✨ Feat: 마이페이지 회원 탈퇴 기능 구현

### DIFF
--- a/panda.config.ts
+++ b/panda.config.ts
@@ -18,7 +18,24 @@ export default defineConfig({
         base: '0px',
         md: '768px',
       },
-
+      keyframes: {
+        /**
+         * 흔들림(shake) 효과를 주는 애니메이션
+         * - 주로 에러/실패/경고 MODAL에서 사용
+         * - 사용 예시: animation: 'shake 0.5s'
+         * @example
+         * <div className={css({ animation: 'shake 0.4s' }) />
+         */
+        shake: {
+          '0%': { transform: 'translateX(0)' },
+          '10%': { transform: 'translateX(10px)' },
+          '20%': { transform: 'translateX(-10px)' },
+          '40%': { transform: 'translateX(10px)' },
+          '60%': { transform: 'translateX(-10px)' },
+          '80%': { transform: 'translateX(10px)' },
+          '100%': { transform: 'translateX(0)' },
+        },
+      },
       tokens: {
         colors: {
           blue: {

--- a/src/app/api/user/userApi.ts
+++ b/src/app/api/user/userApi.ts
@@ -55,9 +55,23 @@ export const updateUserProfileImage = async (file: File): Promise<User> => {
   });
 
   if (!response.ok) {
-    console.error('Profile image update response:', response);
     throw new Error('Failed to update profile image');
   }
 
   return response.json();
+};
+
+export const withdrawUser = async (refresh: string): Promise<boolean> => {
+  const response = await apiRequest(`${BASE_URL}${ENDPOINTS.USERS.WITHDRAW}`, {
+    method: 'DELETE',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ refresh }),
+  });
+
+  if (response.status !== 204) {
+    throw new Error('회원 탈퇴 실패');
+  }
+  return true;
 };

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -1,10 +1,16 @@
+'use client';
+
 import { mypageContainer } from '@/components/mypage/mypage.recipe';
 import MypageMenuList from '@/components/mypage/MypageMenuList';
 import MypageProfile from '@/components/mypage/MypageProfile';
 import MypageStats from '@/components/mypage/MypageStats';
+import WithdrawalConfirmModal from '@/components/mypage/WithdrawalConfirmModal';
 import PageHeader from '@/components/ui/common/pageHeader/PageHeader';
+import { useModalStore } from '@/store/useModalStore';
 
 export default function MypagePage() {
+  const { isOpen } = useModalStore();
+
   return (
     <>
       <PageHeader title="마이페이지" />
@@ -13,6 +19,7 @@ export default function MypagePage() {
         <MypageStats />
         <MypageMenuList />
       </div>
+      {isOpen && <WithdrawalConfirmModal />}
     </>
   );
 }

--- a/src/components/mypage/MypageMenuList.tsx
+++ b/src/components/mypage/MypageMenuList.tsx
@@ -12,6 +12,7 @@ import {
   VersionIcon,
 } from '@/components/icons';
 import IconWrapper from '@/components/icons/IconWrapper';
+import { useModalStore } from '@/store/useModalStore';
 
 import {
   menuButton,
@@ -32,6 +33,7 @@ interface MenuItem {
 
 export default function MypageMenuList() {
   const router = useRouter();
+  const { open } = useModalStore();
 
   const menuItems: MenuItem[] = [
     {
@@ -63,8 +65,7 @@ export default function MypageMenuList() {
       icon: LogoutIcon,
       colorMode: 'stroke',
       action: () => {
-        // 회원 탈퇴 로직
-        router.push('/');
+        open();
       },
     },
   ];

--- a/src/components/mypage/MypageProfile.tsx
+++ b/src/components/mypage/MypageProfile.tsx
@@ -5,6 +5,7 @@ import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 
 import { PenIcon } from '@/components/icons';
+import Modal from '@/components/ui/common/modals/Modal';
 import { useUserProfile } from '@/hooks/useUserProfile';
 import { useAuthStore } from '@/store/useAuthStore';
 
@@ -36,6 +37,9 @@ export default function MypageProfile() {
   const [isEditingNickname, setIsEditingNickname] = useState(false);
   const [isUpdating, setIsUpdating] = useState(false);
 
+  // 에러 관리
+  const [error, setError] = useState<string | null>(null);
+
   const fileInputRef = useRef<HTMLInputElement>(null);
   const nicknameInputRef = useRef<HTMLInputElement>(null);
 
@@ -66,6 +70,16 @@ export default function MypageProfile() {
     }
   }, [profile?.profileImage, user?.profile_image]);
 
+  // 에러 모달 닫기
+  const handleErrorModalClose = () => {
+    setError(null);
+  };
+
+  // 에러 모달 띄우기
+  const showError = (message: string) => {
+    setError(message);
+  };
+
   const handleImageClick = () => {
     fileInputRef.current?.click();
   };
@@ -78,7 +92,7 @@ export default function MypageProfile() {
 
         const maxSize = 2 * 1024 * 1024;
         if (file.size > maxSize) {
-          alert('파일 크기는 2MB 이하여야 합니다.');
+          showError('파일 크기는 2MB 이하여야 합니다.');
           return;
         }
 
@@ -86,8 +100,7 @@ export default function MypageProfile() {
         await refetch();
         setProfileImageUrl(`${newImageUrl}?t=${Date.now()}`);
       } catch (error) {
-        console.error('프로필 이미지 업로드 실패:', error);
-        alert(
+        showError(
           error instanceof Error
             ? error.message
             : '프로필 이미지 업로드에 실패했습니다.',
@@ -109,8 +122,7 @@ export default function MypageProfile() {
           await updateUserNickname(nicknameValue);
           await refetch();
         } catch (error) {
-          console.error('닉네임 변경 실패:', error);
-          alert('닉네임 변경에 실패했습니다.');
+          showError('닉네임 변경에 실패했습니다.');
           setNicknameValue(profile?.nickname || user?.nickname || '');
         } finally {
           setIsUpdating(false);
@@ -136,6 +148,15 @@ export default function MypageProfile() {
 
   return (
     <div className={profileSection()}>
+      {/* 에러 모달 */}
+      {error && (
+        <Modal
+          title="에러"
+          content={error}
+          type="one"
+          onConfirm={handleErrorModalClose}
+        />
+      )}
       <div className={avatarWrapper()}>
         <button
           type="button"

--- a/src/components/mypage/WithdrawalConfirmModal.tsx
+++ b/src/components/mypage/WithdrawalConfirmModal.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+import { withdrawUser } from '@/app/api/user/userApi';
+import { SpinnerMessage } from '@/components/ui/common/loading/SpinnerMessage';
+import Modal from '@/components/ui/common/modals/Modal';
+import { useAuthStore } from '@/store/useAuthStore';
+import { useModalStore } from '@/store/useModalStore';
+
+import { css } from '@root/styled-system/css';
+
+function WithdrawalConfirmModal() {
+  const router = useRouter();
+  const { close } = useModalStore();
+  const { clearAuth, refresh } = useAuthStore();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [shake, setShake] = useState(false);
+
+  const shakeClass = css({ animation: 'shake 0.5s' });
+
+  const handleWithdraw = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      if (!refresh) throw new Error('로그인 정보가 없습니다.');
+      await withdrawUser(refresh);
+      clearAuth();
+      close();
+      router.replace('/');
+    } catch (e: any) {
+      setError('회원 탈퇴에 실패했습니다. 다시 시도해주세요.');
+      setShake(true);
+      setTimeout(() => setShake(false), 400);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleCloseError = () => {
+    setError(null);
+    setShake(false);
+  };
+
+  if (loading) {
+    return (
+      <Modal
+        content={<SpinnerMessage message="회원 탈퇴 처리 중..." />}
+        type="one"
+      />
+    );
+  }
+
+  return (
+    <Modal
+      title={error ? '탈퇴 처리 실패' : '정말 탈퇴하시겠어요?'}
+      content={
+        error ? (
+          <span>{error}</span>
+        ) : (
+          <>
+            탈퇴 시 모든 정보가 삭제되며,
+            <br />
+            복구는 불가능합니다.
+          </>
+        )
+      }
+      type={error ? 'one' : 'two'}
+      onConfirm={error ? handleCloseError : handleWithdraw}
+      className={shake ? shakeClass : ''}
+    />
+  );
+}
+
+export default WithdrawalConfirmModal;

--- a/src/components/mypage/WithdrawalConfirmModal.tsx
+++ b/src/components/mypage/WithdrawalConfirmModal.tsx
@@ -30,10 +30,14 @@ function WithdrawalConfirmModal() {
       clearAuth();
       close();
       router.replace('/');
-    } catch (e: any) {
-      setError('회원 탈퇴에 실패했습니다. 다시 시도해주세요.');
+    } catch (e: unknown) {
+      const errorMessage =
+        e instanceof Error
+          ? e.message
+          : '회원 탈퇴에 실패했습니다. 다시 시도해주세요.';
+      setError(errorMessage);
       setShake(true);
-      setTimeout(() => setShake(false), 400);
+      setTimeout(() => setShake(false), 500);
     } finally {
       setLoading(false);
     }

--- a/src/components/ui/common/modals/Modal.tsx
+++ b/src/components/ui/common/modals/Modal.tsx
@@ -19,6 +19,7 @@ type ModalProps = {
   type?: 'one' | 'two';
   onConfirm?: () => void;
   children?: ReactNode;
+  className?: string;
 };
 
 /**
@@ -45,6 +46,7 @@ type ModalProps = {
  */
 
 function Modal({
+  className = '',
   title,
   content,
   type = 'two',
@@ -58,7 +60,7 @@ function Modal({
 
   return (
     <div className={modalWrapper()}>
-      <div ref={modalRef} className={modalContent()}>
+      <div ref={modalRef} className={`${modalContent()} ${className || ''}`}>
         {children || (
           <>
             <div className={flex({ align: 'center', gap: 'xl' })}>

--- a/src/components/ui/common/modals/modal.recipe.ts
+++ b/src/components/ui/common/modals/modal.recipe.ts
@@ -4,7 +4,7 @@ export const modalWrapper = cva({
   base: {
     position: 'fixed',
     inset: 0,
-    zIndex: '50',
+    zIndex: '9999',
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #150 

## 📝 작업 목록
- [x] shake 애니메이션 설정
- [x] 회원 탈퇴 API 연동
- [x] Confirm Modal 렌더링 및 마이페이지 메뉴 연결
- [x] Alert를 Modal 컴포넌트로 전환

## 🙋‍♀️ 기타 참고사항(선택)
![image](https://github.com/user-attachments/assets/233c44bd-366a-4693-942c-0b88a75bbc91)
![image](https://github.com/user-attachments/assets/607a1e2f-e86f-4f60-9834-68f73a6f772e)
![image](https://github.com/user-attachments/assets/418c2273-c536-4634-84e7-182811d3f981)
![image](https://github.com/user-attachments/assets/56b07bfe-7ec0-4c51-898b-03a435f23419)
![image](https://github.com/user-attachments/assets/3098b5aa-9f45-4804-b3b3-04fcd94673b0)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 회원탈퇴 확인 모달이 추가되어, 탈퇴 시 확인 및 안내를 제공합니다.
    - shake 애니메이션이 테마에 추가되어 오류 또는 경고 상황에서 시각적 피드백을 제공합니다.
- **개선 사항**
    - 마이페이지 메뉴에서 회원탈퇴 선택 시 모달이 열리도록 변경되었습니다.
    - 마이페이지 프로필에서 오류 발생 시 alert 대신 모달로 안내 메시지를 표시합니다.
    - 모달 컴포넌트에 외부 스타일 적용을 위한 className 속성이 추가되었습니다.
    - 모달의 z-index가 높아져 다른 요소 위에 항상 표시됩니다.
- **버그 수정**
    - 프로필 이미지 업로드 및 닉네임 변경 실패 시 일관된 오류 안내가 제공됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->