### PR TITLE
✨ Feat: 마이페이지 설정 페이지 구현

### DIFF
--- a/src/app/mypage/settings/NotificationList.tsx
+++ b/src/app/mypage/settings/NotificationList.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import OpenBookIcon from '@/components/icons/business/OpenBookIcon';
+import UserIcon from '@/components/icons/business/UserIcon';
+import IconWrapper from '@/components/icons/IconWrapper';
+import CommentsIcon from '@/components/icons/ui/CommentsIcon';
+import { Switches } from '@/components/ui/common/toggles/Switch';
+import { useNotificationStore } from '@/store/useNotificationStore';
+
+import { css } from '@root/styled-system/css';
+
+const NOTIFICATION_TYPES = ['follower', 'post', 'comment'] as const;
+type NotificationType = (typeof NOTIFICATION_TYPES)[number];
+
+const NOTIFICATION_LABELS: Record<NotificationType, string> = {
+  follower: '팔로우 알림',
+  post: '게시물 알림',
+  comment: '댓글 알림',
+} as const;
+
+const NOTIFICATION_ICONS: Record<NotificationType, React.ComponentType<any>> = {
+  follower: UserIcon,
+  post: OpenBookIcon,
+  comment: CommentsIcon,
+} as const;
+
+export default function NotificationList() {
+  const { settings, updateSetting } = useNotificationStore();
+
+  return (
+    <div
+      className={css({
+        width: '100%',
+        bg: 'white',
+        borderRadius: 'lg',
+        boxShadow: 'sm',
+        py: '4px',
+        px: '0px',
+        maxWidth: '100%',
+      })}
+    >
+      {settings.map((setting, idx) => {
+        const type = setting.type as NotificationType;
+        const IconComponent = NOTIFICATION_ICONS[type];
+        const iconOpacity = setting.enabled ? 0.8 : 0.2;
+
+        return (
+          <div
+            key={setting.type}
+            className={css({
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              py: '12px',
+              px: '20px',
+              borderBottom: idx < settings.length - 1 ? '1px solid' : 'none',
+              borderColor: 'gray.100',
+              gap: '16px',
+            })}
+          >
+            <div
+              className={css({
+                display: 'flex',
+                alignItems: 'center',
+                gap: '12px',
+              })}
+            >
+              <IconWrapper size={22} style={{ opacity: iconOpacity }}>
+                <IconComponent />
+              </IconWrapper>
+              <span
+                className={css({
+                  fontSize: '16px',
+                  fontWeight: 400,
+                  color: 'text',
+                })}
+              >
+                {NOTIFICATION_LABELS[type]}
+              </span>
+            </div>
+            <Switches
+              checked={setting.enabled}
+              onChange={checked => updateSetting(setting.type, checked)}
+              aria-label={NOTIFICATION_LABELS[type]}
+            />
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/app/mypage/settings/layout.tsx
+++ b/src/app/mypage/settings/layout.tsx
@@ -1,0 +1,15 @@
+import { mypageContainer } from '@/components/mypage/mypage.recipe';
+import PageHeader from '@/components/ui/common/pageHeader/PageHeader';
+
+export default function SettingsLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <>
+      <PageHeader title="설정" />
+      <div className={mypageContainer()}>{children}</div>
+    </>
+  );
+}

--- a/src/app/mypage/settings/page.tsx
+++ b/src/app/mypage/settings/page.tsx
@@ -1,0 +1,9 @@
+import NotificationList from './NotificationList';
+
+export default function MypageSettingsPage() {
+  return (
+    <section style={{ width: '100%' }}>
+      <NotificationList />
+    </section>
+  );
+}

--- a/src/components/icons/IconWrapper.tsx
+++ b/src/components/icons/IconWrapper.tsx
@@ -11,6 +11,7 @@ interface IconWrapperProps {
   strokeWidth?: number;
   className?: string;
   colorMode?: 'auto' | 'fill' | 'stroke' | 'both';
+  style?: React.CSSProperties;
 }
 
 export default function IconWrapper({
@@ -20,6 +21,7 @@ export default function IconWrapper({
   strokeWidth,
   className,
   colorMode = 'auto',
+  style,
 }: IconWrapperProps) {
   const getColorProps = () => {
     switch (colorMode) {
@@ -54,5 +56,9 @@ export default function IconWrapper({
     style: { width: `${size}px`, height: `${size}px` },
   });
 
-  return <span className={combinedClassName}>{clonedIcon}</span>;
+  return (
+    <span className={combinedClassName} style={style}>
+      {clonedIcon}
+    </span>
+  );
 }

--- a/src/store/useNotificationStore.ts
+++ b/src/store/useNotificationStore.ts
@@ -1,0 +1,29 @@
+import { create } from 'zustand';
+
+import type { NotificationSetting } from '@/types/settings';
+
+// 가짜 데이터 - 초기값(실제 API 연동 시 대체)
+const DEFAULT_SETTINGS: NotificationSetting[] = [
+  { id: 1, type: 'follower', enabled: true, createdAt: '', updatedAt: '' },
+  { id: 2, type: 'post', enabled: false, createdAt: '', updatedAt: '' },
+  { id: 3, type: 'comment', enabled: true, createdAt: '', updatedAt: '' },
+];
+
+// Zustand 사용(공통 알림 설정 상태)
+interface NotificationState {
+  settings: NotificationSetting[];
+  setSettings: (settings: NotificationSetting[]) => void;
+  updateSetting: (type: string, enabled: boolean) => void;
+}
+
+export const useNotificationStore = create<NotificationState>((set, get) => ({
+  settings: DEFAULT_SETTINGS,
+  setSettings: settings => set({ settings }),
+  updateSetting: (type, enabled) => {
+    set(state => ({
+      settings: state.settings.map(s =>
+        s.type === type ? { ...s, enabled } : s,
+      ),
+    }));
+  },
+}));

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -1,0 +1,7 @@
+export interface NotificationSetting {
+  id: number;
+  type: 'follower' | 'post' | 'comment';
+  enabled: boolean;
+  createdAt: string;
+  updatedAt: string;
+}


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #166 

## 📝 작업 목록
- [x] 설정 페이지 마크업 및 토글 스위치 렌더링 (상태 관리 포함)

## 🙋‍♀️ 기타 참고사항(선택)
![screencapture-localhost-3000-mypage-settings-2025-06-25-02_12_23](https://github.com/user-attachments/assets/dc299742-286a-4507-ac66-813fb9c2dc8e)
![screencapture-localhost-3000-mypage-settings-2025-06-25-02_12_36](https://github.com/user-attachments/assets/76c114b2-3371-4aec-a86e-d94c2add1d55)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 알림 설정 목록과 토글 기능이 포함된 알림 설정 페이지가 추가되었습니다.
  - 설정 페이지에 일관된 헤더와 컨테이너 스타일이 적용되었습니다.
  - 알림 설정(팔로워, 게시글, 댓글)에 대한 개별 활성화/비활성화 토글이 제공됩니다.

- **개선 사항**
  - 아이콘 컴포넌트에 외부 스타일을 적용할 수 있는 기능이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->