### PR TITLE
🐛   Fix: 소켓 라이브러리를 내장 웹소켓으로 변경

### DIFF
--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -13,7 +13,7 @@ export const ENDPOINTS = {
   },
   NOTIFICATIONS: {
     LIST: '/notifications/notifications/', // get, post
-    DETAIL: (id: string) => `/notifications/${id}/`, // get, put, patch, delete
+    DETAIL: (id: string) => `/notifications/notifications/${id}/`, // get, put, patch, delete
   },
   SEARCH: {
     LIST: '/search/',

--- a/src/app/mypage/settings/NotificationList.tsx
+++ b/src/app/mypage/settings/NotificationList.tsx
@@ -6,7 +6,7 @@ import { instance } from '@api/instance';
 import { notificationOption } from '@api/options/notificationOption';
 import IconWrapper from '@components/icons/IconWrapper';
 import { Switches } from '@components/ui/common/toggles';
-import { useNotificationSocket } from '@hooks/useNotificationSocket';
+import { useNotificationWebSocket } from '@hooks/useNotificationSocket';
 import { useAuthStore } from '@store/useAuthStore';
 import { useMutation, useQuery } from '@tanstack/react-query';
 
@@ -36,7 +36,7 @@ export default function NotificationList() {
   const { settings, setSettings, updateSetting } = useNotificationStore();
   const { user } = useAuthStore();
   const userId = user?.id ? user?.id : undefined;
-  useNotificationSocket(String(userId));
+  useNotificationWebSocket(String(userId));
   const { data, isError, isLoading } = useQuery({
     queryKey: ['notice'],
     queryFn: () =>

--- a/src/hooks/useNotificationSocket.ts
+++ b/src/hooks/useNotificationSocket.ts
@@ -1,26 +1,37 @@
-import { useEffect, useState } from 'react';
-import { io, Socket } from 'socket.io-client';
+import { useEffect } from 'react';
 
-import type { NotificationSetting } from '@/types/settings';
-
-export function useNotificationSocket(userId: string | undefined) {
-  const [notifications, setNotifications] = useState<NotificationSetting[]>([]);
-
+export function useNotificationWebSocket(userId: string | undefined) {
   useEffect(() => {
     if (!userId) return undefined;
 
-    const socket: Socket = io('http://localhost:8000/', { query: { userId } });
+    const ws = new WebSocket(
+      `ws://localhost:8000/ws/notifications?userId=${userId}`,
+    );
 
-    socket.on('notification', notification => {
-      setNotifications(prev => [notification, ...prev]);
-      // TODO: 토스트 알림이나 인앱 알림 컴포넌트로 교체
-      alert('알림 옴');
-    });
+    ws.onopen = () => {
+      // 연결 성공 시
+      console.log('WebSocket connected');
+    };
+
+    ws.onmessage = event => {
+      try {
+        const data = JSON.parse(event.data);
+        alert(data.message || '새 알림이 도착했습니다!');
+      } catch (e) {
+        console.error('Invalid message:', event.data);
+      }
+    };
+
+    ws.onerror = error => {
+      console.error('WebSocket error:', error);
+    };
+
+    ws.onclose = () => {
+      console.log('WebSocket disconnected');
+    };
 
     return () => {
-      socket.disconnect();
+      ws.close();
     };
   }, [userId]);
-
-  return notifications;
 }


### PR DESCRIPTION
## 🔗 관련 이슈

- 이 PR이 해결하는 이슈 번호를 명시해주세요.
- Close #179 

## 📝 작업 목록

- [ ]  소켓 라이브러리를 내장 웹소켓으로 변경

## 🙋‍♀️ 기타 참고사항(선택)

- 리뷰어가 참고하면 좋을 내용이 있다면 적어주세요. (스크린샷, 리뷰 요구사항 등)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 알림 상세 조회, 수정, 삭제 시 사용되는 경로가 `/notifications/notifications/{id}/`로 변경되어 일부 알림 관련 기능의 접근 오류가 해결되었습니다.

- **리팩터**
  - 알림 실시간 수신 기능이 Socket.IO에서 웹 표준 WebSocket 방식으로 개선되었습니다.  
  - 알림 관련 설정에서 사용하는 훅 이름이 변경되고, 내부 동작이 간소화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->