### PR TITLE
🐛 Fix: story post 완료 시 라우팅 경로 응답값 이용하도록 수정

### DIFF
--- a/src/components/story/StoryPostForm.tsx
+++ b/src/components/story/StoryPostForm.tsx
@@ -51,7 +51,7 @@ function StoryPostForm({ initialData, storyId }: Props) {
 
   const postMutation = useMutation({
     ...storyOption.postStory(),
-    onSuccess: () => router.push(`/story/${storyId}`),
+    onSuccess: res => router.push(`/story/${res.storyId}`),
   });
 
   const patchMutation = useMutation({


### PR DESCRIPTION
## 🔗 관련 이슈

Closes #192 

## 📝 작업 목록

- [x] 스토리 post mutation onsuccess 로직 수정

## 🙋‍♀️ 기타 참고사항(선택)

- 리뷰어가 참고하면 좋을 내용이 있다면 적어주세요. (스크린샷, 리뷰 요구사항 등)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 게시글 작성 후 리디렉션 시, 이제 실제로 생성된 게시글의 ID를 사용하여 올바른 페이지로 이동합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->